### PR TITLE
Upgraded keycloak version to v9.0.0

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -1,3 +1,3 @@
 tdr.base.url="http://localhost:9000"
-tdr.auth.url="http://localhost:8080"
+tdr.auth.url="http://localhost:8081"
 redirect.base.url="https://www.google.co.uk/"

--- a/build.sbt
+++ b/build.sbt
@@ -5,13 +5,8 @@ version := "0.1"
 scalaVersion := "2.13.1"
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
-libraryDependencies += "org.keycloak" % "keycloak-core" % "7.0.1" % Test
-libraryDependencies += "org.keycloak" % "keycloak-admin-client" % "7.0.1" % Test
-
-libraryDependencies += "javax.ws.rs" % "javax.ws.rs-api" % "2.1.1" % Test
-libraryDependencies += "org.jboss.resteasy" % "resteasy-client" % "3.6.0.Final" % Test
-libraryDependencies += "org.jboss.resteasy" % "resteasy-jackson2-provider" % "3.6.0.Final" % Test
-libraryDependencies += "org.jboss.resteasy" % "resteasy-multipart-provider" % "3.6.0.Final" % Test
+libraryDependencies += "org.keycloak" % "keycloak-core" % "9.0.0" % Test
+libraryDependencies += "org.keycloak" % "keycloak-admin-client" % "9.0.0" % Test
 
 libraryDependencies ++= Seq(
   "io.cucumber" % "cucumber-core" % "4.7.1" % "test",


### PR DESCRIPTION
Keycloak auth server has been updated to use v9.0.0. Client Keycloak version must match server version

Removed unnecessary dependencies following upgrade to newer version of Keycloak

Changed local auth port to match local auth server setup instructions