### PR TITLE
Get existing e2e test up to date with TDR

### DIFF
--- a/src/test/resources/features/Login.feature
+++ b/src/test/resources/features/Login.feature
@@ -1,33 +1,30 @@
 Feature: Login
 
-  Scenario: Navigate to TDR Home Page as a logged out user
+  Scenario: Navigate to the TDR home page as a logged out user
     Given A logged out user
     When the logged out user navigates to TDR Home Page
-    And the logged out user clicks the .govuk-button--start element
+    And the user clicks the .govuk-button--start element
     Then the logged out user should be at the auth page
-    And the logged out user enters valid credentials
-    And the logged out user clicks the [name='login'] element
-    Then the logged in user should be at the dashboard page
 
-  Scenario: Navigate to TDR Home Page as a logged out user with incorrect credentials
+  Scenario: Navigate to the TDR home page as a logged in user
+    Given A logged in user
+    When the logged out user navigates to TDR Home Page
+    And the user clicks the .govuk-button--start element
+    Then the user should be at the dashboard page
+
+  Scenario: Log in to TDR with correct credentials
     Given A logged out user
     When the logged out user navigates to TDR Home Page
-    And the logged out user clicks the .govuk-button--start element
-    Then the logged out user should be at the auth page
+    And the user clicks the .govuk-button--start element
+    And the logged out user enters valid credentials
+    And the user clicks the [name='login'] element
+    Then the user should be at the dashboard page
+
+  Scenario: Log in to TDR with incorrect credentials
+    Given A logged out user
+    When the logged out user navigates to TDR Home Page
+    And the user clicks the .govuk-button--start element
     And the logged out user enters invalid credentials
-    And the logged out user clicks the [name='login'] element
-    Then the logged out user will remain on the auth page
-    And the user will see an error message
-
-  Scenario: Navigate to TDR Home Page as a logged in user with correct credentials and navigate away
-    Given A logged out user
-    When the logged out user navigates to TDR Home Page
-    And the logged out user clicks the .govuk-button--start element
-    Then the logged out user should be at the auth page
-    And the logged out user enters valid credentials
-    And the logged out user clicks the [name='login'] element
-    Then the logged in user should be at the dashboard page
-    When the logged in user navigates to another website
-    And the logged in user navigates back to TDR Home Page
-    And the logged in user clicks the .govuk-button--start element
-    Then the logged in user should be at the dashboard page
+    And the user clicks the [name='login'] element
+    Then the user will remain on the auth page
+    And the user will see the error message Invalid username or password.

--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -3,18 +3,20 @@ Feature: Series Page
   Scenario: Logged in user selects nothing from dropdown
     Given A logged in user
     When the logged in user navigates to the series page
-    And the logged in user selects nothing
+    And the user clicks the .govuk-button element
     Then the logged in user should stay at the series page
+    And the user will see a form error message This field is required
 
-  Scenario: Logged in user selects series from dropdown
+  Scenario: Logged in user selects a series from the dropdown
     Given A logged in user
     When the logged in user navigates to the series page
-    And the logged in user selects the .govuk-select element
-    And the logged in user clicks a series
-    Then the logged in user should stay at the series page
+    And the user clicks the .govuk-select element
+    And the logged in user selects the series MOCK1 123
+    And the user clicks the continue button
+    Then the user should be at the transfer-agreement page
 
-  Scenario: Logged in user selects 'back' from Series page
+  Scenario: Logged in user selects 'back' when on Series page
     Given A logged in user
     When the logged in user navigates to the series page
-    And the logged in user selects the .govuk-back-link element
-    Then the logged in user should be at the dashboard page
+    And the user clicks the .govuk-back-link element
+    Then the user should be at the dashboard page

--- a/src/test/scala/helpers/users/KeycloakClient.scala
+++ b/src/test/scala/helpers/users/KeycloakClient.scala
@@ -40,6 +40,9 @@ object KeycloakClient {
     userRepresentation.setUsername(userCredentials.userName)
     userRepresentation.setEnabled(true)
     userRepresentation.setCredentials(creds)
+    userRepresentation.setAttributes(Map("body" -> List("MOCK1 Department").asJava).asJava)
+    userRepresentation.setRealmRoles(List("tdr_user").asJava)
+
 
     val response: Response = userResource.create(userRepresentation)
 

--- a/src/test/scala/helpers/users/KeycloakClient.scala
+++ b/src/test/scala/helpers/users/KeycloakClient.scala
@@ -42,8 +42,7 @@ object KeycloakClient {
     userRepresentation.setCredentials(creds)
     userRepresentation.setAttributes(Map("body" -> List("MOCK1 Department").asJava).asJava)
     userRepresentation.setRealmRoles(List("tdr_user").asJava)
-
-
+    
     val response: Response = userResource.create(userRepresentation)
 
     response.getLocation.getPath.replaceAll(".*/([^/]+)$", "$1")


### PR DESCRIPTION
These e2e test alterations mean that they now work after the major changes TDR has gone through in the past few weeks. These changes will apply to a dedicated Jenkins build, though more changes may need to be made so that the tests work on Jenkins.

After looking at Jenkins build options for the e2e tests, I think my changes need to be merged into master before I can start to try getting them working on Jenkins.