### PR TITLE
Fix test wording and refactor.

### DIFF
--- a/src/test/resources/features/Login.feature
+++ b/src/test/resources/features/Login.feature
@@ -2,19 +2,19 @@ Feature: Login
 
   Scenario: Navigate to the TDR home page as a logged out user
     Given A logged out user
-    When the logged out user navigates to TDR Home Page
+    When the user navigates to TDR Home Page
     And the user clicks the .govuk-button--start element
     Then the logged out user should be at the auth page
 
   Scenario: Navigate to the TDR home page as a logged in user
     Given A logged in user
-    When the logged out user navigates to TDR Home Page
+    When the user navigates to TDR Home Page
     And the user clicks the .govuk-button--start element
     Then the user should be at the dashboard page
 
   Scenario: Log in to TDR with correct credentials
     Given A logged out user
-    When the logged out user navigates to TDR Home Page
+    When the user navigates to TDR Home Page
     And the user clicks the .govuk-button--start element
     And the logged out user enters valid credentials
     And the user clicks the [name='login'] element
@@ -22,7 +22,7 @@ Feature: Login
 
   Scenario: Log in to TDR with incorrect credentials
     Given A logged out user
-    When the logged out user navigates to TDR Home Page
+    When the user navigates to TDR Home Page
     And the user clicks the .govuk-button--start element
     And the logged out user enters invalid credentials
     And the user clicks the [name='login'] element

--- a/src/test/scala/helpers/users/KeycloakClient.scala
+++ b/src/test/scala/helpers/users/KeycloakClient.scala
@@ -42,7 +42,7 @@ object KeycloakClient {
     userRepresentation.setCredentials(creds)
     userRepresentation.setAttributes(Map("body" -> List("MOCK1 Department").asJava).asJava)
     userRepresentation.setRealmRoles(List("tdr_user").asJava)
-    
+
     val response: Response = userResource.create(userRepresentation)
 
     response.getLocation.getPath.replaceAll(".*/([^/]+)$", "$1")

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.ConfigFactory
 import cucumber.api.scala.{EN, ScalaDsl}
 import helpers.steps.StepsUtility
 import helpers.users.{KeycloakClient, RandomUtility, UserCredentials}
+import org.hamcrest.CoreMatchers
 import org.junit.Assert
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.{By, WebDriver, WebElement}
@@ -45,7 +46,7 @@ class Steps extends ScalaDsl with EN with Matchers {
     StepsUtility.userLogin(webDriver, userCredentials)
   }
 
-  When("^the logged out user navigates to TDR Home Page") {
+  When("^the user navigates to TDR Home Page") {
     webDriver.get(s"$baseUrl")
   }
 
@@ -83,7 +84,7 @@ class Steps extends ScalaDsl with EN with Matchers {
     page: String =>
       val currentUrl: String = webDriver.getCurrentUrl
 
-      Assert.assertTrue(currentUrl.startsWith(s"$baseUrl/$page") || currentUrl.endsWith(page))
+      Assert.assertTrue(s"actual: $currentUrl, expected: $page", currentUrl.startsWith(s"$baseUrl/$page") || currentUrl.endsWith(page))
   }
 
   Then("^the user will remain on the (.*) page") {
@@ -110,12 +111,6 @@ class Steps extends ScalaDsl with EN with Matchers {
     page: String =>
       val currentUrl: String = webDriver.getCurrentUrl
       Assert.assertTrue(currentUrl.startsWith(s"$baseUrl/$page"))
-  }
-
-  And("^the logged in user selects the (.*) element$") {
-    selector: String =>
-      val clickableElement = webDriver.findElement(By.cssSelector(selector))
-      clickableElement.click()
   }
 
   And("^the logged in user selects the series (.*)") {


### PR DESCRIPTION
One of the tests had the wrong wording meaning it defaulted to a different step and was ambiguous. This is now changed, and a step that is not used has been removed.