### PR TITLE
Notify Slack when the tests start passing again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,22 +75,18 @@ pipeline {
     }
     post {
         failure {
-            node('master') {
-                slackSend(
-                    color: '#FF0000', //red
-                    message: " :warning: *End to End Test Failure*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html",
-                    channel: "#tdr-releases"
-                )
-            }
+            slackSend(
+                color: '#FF0000', //red
+                message: " :warning: *End to End Test Failure*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html",
+                channel: "#tdr-releases"
+            )
         }
         fixed {
-            node('master') {
-                slackSend(
-                    color: '#00FF00', //green
-                    message: " :green_heart: *End to End Tests Succeeded*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html",
-                    channel: "#tdr-releases"
-                )
-            }
+            slackSend(
+                color: '#00FF00', //green
+                message: " :green_heart: *End to End Tests Succeeded*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html",
+                channel: "#tdr-releases"
+            )
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,17 @@ pipeline {
             node('master') {
                 slackSend(
                     color: '#FF0000', //red
-                    message: " :warning: *End to End Test Failure*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html", channel: "#tdr-releases"
+                    message: " :warning: *End to End Test Failure*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html",
+                    channel: "#tdr-releases"
+                )
+            }
+        }
+        fixed {
+            node('master') {
+                slackSend(
+                    color: '#00FF00', //green
+                    message: " :green_heart: *End to End Tests Succeeded*\n *TDR Environment*: ${params.STAGE}\n *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html",
+                    channel: "#tdr-releases"
                 )
             }
         }


### PR DESCRIPTION
Let developers know when failing end-to-end tests have been fixed. This shouldn't add too much noise because it won't notify Slack on _every_ successful build, just when the build goes from red to green.