### PR TITLE
Add e2e tests for Transfer Agreement Page

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -1,4 +1,3 @@
 tdr.base.url="http://localhost:9000"
 tdr.auth.url="http://localhost:8081"
 tdr.api.url="http://localhost:8080/graphql"
-redirect.base.url="https://www.google.co.uk/"

--- a/application.intg.conf
+++ b/application.intg.conf
@@ -1,4 +1,3 @@
 tdr.base.url="https://tdr-integration.nationalarchives.gov.uk"
 tdr.auth.url="https://auth.tdr-integration.nationalarchives.gov.uk"
 tdr.api.url="https://api.tdr-integration.nationalarchives.gov.uk/graphql"
-redirect.base.url="https://www.google.co.uk/"

--- a/application.staging.conf
+++ b/application.staging.conf
@@ -1,4 +1,3 @@
 tdr.base.url="https://tdr-staging.nationalarchives.gov.uk"
 tdr.auth.url="https://auth.tdr-staging.nationalarchives.gov.uk"
 tdr.api.url="https://api.tdr-staging.nationalarchives.gov.uk/graphql"
-redirect.base.url="https://www.google.co.uk/"

--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -10,8 +10,7 @@ Feature: Series Page
   Scenario: Logged in user selects a series from the dropdown
     Given A logged in user
     When the logged in user navigates to the series page
-    And the user clicks the .govuk-select element
-    And the logged in user selects the series MOCK1 123
+    And the user selects the series MOCK1 123
     And the user clicks the continue button
     Then the user should be at the transfer-agreement page
 

--- a/src/test/resources/features/TransferAgreement.feature
+++ b/src/test/resources/features/TransferAgreement.feature
@@ -1,14 +1,10 @@
 Feature: Transfer Agreement Page
 
   Scenario: A logged in user completes the Transfer Agreement form correctly
-    Given A logged in user
-    And the logged in user navigates to the series page
-    And the user clicks the .govuk-select element
-    And the logged in user selects the series MOCK1 123
-    And the user clicks the continue button
-    And the user navigates to the transfer-agreement page
+    Given an existing user
+    And an existing consignment for transferring body MOCK1 Department
+    And the user is logged in on the Transfer Agreement page
     When the user selects yes to all transfer agreement checks
-    And the user clicks the droAppraisalSelection checkbox
-    And the user clicks the droSensitivity checkbox
+    And the user confirms that DRO has signed off on the records
     And the user clicks the continue button
-    Then the user should be at the upload page
+    Then the user will be on a page with the title Upload Records

--- a/src/test/resources/features/TransferAgreement.feature
+++ b/src/test/resources/features/TransferAgreement.feature
@@ -1,0 +1,14 @@
+Feature: Transfer Agreement Page
+
+  Scenario: A logged in user completes the Transfer Agreement form correctly
+    Given A logged in user
+    And the logged in user navigates to the series page
+    And the user clicks the .govuk-select element
+    And the logged in user selects the series MOCK1 123
+    And the user clicks the continue button
+    And the user navigates to the transfer-agreement page
+    When the user selects yes to all transfer agreement checks
+    And the user clicks the droAppraisalSelection checkbox
+    And the user clicks the droSensitivity checkbox
+    And the user clicks the continue button
+    Then the user should be at the upload page

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -2,7 +2,7 @@ package steps
 
 import java.util.UUID
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import cucumber.api.scala.{EN, ScalaDsl}
 import helpers.graphql.GraphqlUtility
 import helpers.steps.StepsUtility
@@ -20,7 +20,7 @@ class Steps extends ScalaDsl with EN with Matchers {
   var userId: String = ""
   var consignmentId: UUID = _
 
-  val configuration = ConfigFactory.load()
+  val configuration: Config = ConfigFactory.load()
   val baseUrl: String = configuration.getString("tdr.base.url")
   val authUrl: String = configuration.getString("tdr.auth.url")
   val userName: String = RandomUtility.randomString()
@@ -36,11 +36,19 @@ class Steps extends ScalaDsl with EN with Matchers {
     KeycloakClient.deleteUser(userId)
   }
 
-  private def login = {
+  private def login(): Unit = {
     webDriver.get(s"$baseUrl")
     val startElement = webDriver.findElement(By.cssSelector(".govuk-button--start"))
     startElement.click()
     StepsUtility.userLogin(webDriver, userCredentials)
+  }
+
+  private def loadPage(page: String): Unit = {
+    val pageWithConsignment = page match {
+      case "series" => s"$baseUrl/$page"
+      case _ => s"$baseUrl/consignment/$consignmentId/${page.toLowerCase.replaceAll(" ", "-")}"
+    }
+    webDriver.get(pageWithConsignment)
   }
 
   Given("^A logged out user") {
@@ -50,27 +58,27 @@ class Steps extends ScalaDsl with EN with Matchers {
   Given("^A logged in user who is a member of (.*) transferring body") {
     body: String =>
       userId = KeycloakClient.createUser(userCredentials, Some(body))
-      login
+      login()
   }
 
   Given("^A logged in user who is not a member of a transferring body") {
     userId = KeycloakClient.createUser(userCredentials, Option.empty)
-    login
+    login()
   }
 
   Given("^A logged in user") {
     userId = KeycloakClient.createUser(userCredentials)
-    login
+    login()
+  }
+
+  Given("^an existing user") {
+    userId = KeycloakClient.createUser(userCredentials)
   }
 
   And("^the user is logged in on the (.*) page") {
     page: String =>
       loadPage(page)
       StepsUtility.userLogin(webDriver, userCredentials)
-  }
-
-  Given("^an existing user") {
-    userId = KeycloakClient.createUser(userCredentials)
   }
 
   When("^the user navigates to TDR Home Page") {
@@ -99,15 +107,15 @@ class Steps extends ScalaDsl with EN with Matchers {
       loadPage(page)
   }
 
+  And("^the user clicks on the (.*) button") {
+    button: String =>
+      webDriver.findElement(By.linkText(button)).click()
+
+  }
+
   And("^the user clicks the (.*) element$") {
     selector: String =>
       val clickableElement = webDriver.findElement(By.cssSelector(selector))
-      clickableElement.click()
-  }
-
-  And("^the user clicks the (.*) checkbox$") {
-    selector: String =>
-      val clickableElement = webDriver.findElement(By.id(selector))
       clickableElement.click()
   }
 
@@ -136,6 +144,12 @@ class Steps extends ScalaDsl with EN with Matchers {
     page: String =>
       val currentUrl: String = webDriver.getCurrentUrl
       Assert.assertTrue(currentUrl.startsWith(s"$authUrl/$page"))
+  }
+
+  Then("^the user will be on a page with the title (.*)") {
+    page: String =>
+      val pageTitle: String = webDriver.findElement(By.className("govuk-heading-xl")).getText
+      Assert.assertTrue(page == pageTitle)
   }
 
   Then("^the user should see a user specific general error (.*)") {
@@ -183,7 +197,7 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertTrue(currentUrl.startsWith(s"$baseUrl/$page"))
   }
 
-  And("^the logged in user selects the series (.*)") {
+  And ("^the user selects the series (.*)") {
     selectedSeries: String =>
       val seriesDropdown = new Select(webDriver.findElement(By.name("series")))
       seriesDropdown.selectByVisibleText(selectedSeries)
@@ -192,6 +206,19 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the user clicks the continue button") {
     val button = webDriver.findElement(By.cssSelector("[type='submit']"))
     button.click()
+  }
+
+  And("^the user clicks the (.*) checkbox$") {
+    selector: String =>
+      val clickableElement = webDriver.findElement(By.id(selector))
+      clickableElement.click()
+  }
+
+  And ("^the user confirms that DRO has signed off on the records") {
+    val droAppraisalAndSelection = webDriver.findElement(By.id("droAppraisalSelection"))
+    val dropSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
+    droAppraisalAndSelection.click()
+    dropSensitivityAndOpen.click()
   }
 
   And("^an existing consignment for transferring body (.*)") {
@@ -230,14 +257,6 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the page will redirect to the (.*) page after upload is complete") {
     page: String =>
       val _ = new WebDriverWait(webDriver, 10).until(ExpectedConditions.titleContains(page.capitalize))
-  }
-
-  private def loadPage(page: String) = {
-    val pageWithConsignment = page match {
-      case "series" => s"$baseUrl/$page"
-      case _ => s"$baseUrl/consignment/$consignmentId/${page.toLowerCase.replaceAll(" ", "-")}"
-    }
-    webDriver.get(pageWithConsignment)
   }
 
   When("^the user selects yes to all transfer agreement checks") {

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -25,7 +25,6 @@ class Steps extends ScalaDsl with EN with Matchers {
   val authUrl: String = configuration.getString("tdr.auth.url")
   val userName: String = RandomUtility.randomString()
   val password: String = RandomUtility.randomString(10)
-  val nonTdrPageUrl: String = configuration.getString("redirect.base.url")
   val userCredentials: UserCredentials = UserCredentials(userName, password)
 
   Before() { scenario =>
@@ -106,6 +105,12 @@ class Steps extends ScalaDsl with EN with Matchers {
       clickableElement.click()
   }
 
+  And("^the user clicks the (.*) checkbox$") {
+    selector: String =>
+      val clickableElement = webDriver.findElement(By.id(selector))
+      clickableElement.click()
+  }
+
   Then("^the logged out user should be at the (.*) page") {
     page: String =>
       val currentUrl: String = webDriver.getCurrentUrl
@@ -114,6 +119,13 @@ class Steps extends ScalaDsl with EN with Matchers {
   }
 
   Then("^the user should be at the (.*) page") {
+    page: String =>
+      val currentUrl: String = webDriver.getCurrentUrl
+
+      Assert.assertTrue(s"actual: $currentUrl, expected: $page", currentUrl.startsWith(s"$baseUrl/$page") || currentUrl.endsWith(page))
+  }
+
+  And("^the user navigates to the (.*) page") {
     page: String =>
       val currentUrl: String = webDriver.getCurrentUrl
 
@@ -226,5 +238,16 @@ class Steps extends ScalaDsl with EN with Matchers {
       case _ => s"$baseUrl/consignment/$consignmentId/${page.toLowerCase.replaceAll(" ", "-")}"
     }
     webDriver.get(pageWithConsignment)
+  }
+
+  When("^the user selects yes to all transfer agreement checks") {
+    val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecordtrue"))
+    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyrighttrue"))
+    val recordsAllEnglish = webDriver.findElement(By.id("englishtrue"))
+    val recordsAllDigital = webDriver.findElement(By.id("digitaltrue"))
+    recordsAllPublicRecords.click()
+    recordsAllCrownCopyright.click()
+    recordsAllEnglish.click()
+    recordsAllDigital.click()
   }
 }


### PR DESCRIPTION
This change adds e2e test steps for the transfer agreement page. At the moment these changes are could use some refactoring. The transfer agreement form only works when consignment ID is in the URL, but to get to that stage the test 'user' needs to go through the series selection to get directed to the correct transfer agreement page. At the moment this is done by adding quite a few steps to the scenario, but I think it could be smoother.

Also removed some redundant code in the application conf files.