### PR TITLE
Slight refactoring of tests and steps to remove repetitive code

### DIFF
--- a/src/test/resources/features/Login.feature
+++ b/src/test/resources/features/Login.feature
@@ -3,28 +3,28 @@ Feature: Login
   Scenario: Navigate to the TDR home page as a logged out user
     Given A logged out user
     When the user navigates to TDR Home Page
-    And the user clicks the .govuk-button--start element
+    And the user clicks on the Start now button
     Then the logged out user should be at the auth page
 
   Scenario: Navigate to the TDR home page as a logged in user
     Given A logged in user
     When the user navigates to TDR Home Page
-    And the user clicks the .govuk-button--start element
+    And the user clicks on the Start now button
     Then the user should be at the dashboard page
 
   Scenario: Log in to TDR with correct credentials
     Given A logged out user
     When the user navigates to TDR Home Page
-    And the user clicks the .govuk-button--start element
+    And the user clicks on the Start now button
     And the logged out user enters valid credentials
-    And the user clicks the [name='login'] element
+    And the user clicks the continue button
     Then the user should be at the dashboard page
 
   Scenario: Log in to TDR with incorrect credentials
     Given A logged out user
     When the user navigates to TDR Home Page
-    And the user clicks the .govuk-button--start element
+    And the user clicks on the Start now button
     And the logged out user enters invalid credentials
-    And the user clicks the [name='login'] element
+    And the user clicks the continue button
     Then the user will remain on the auth page
     And the user will see the error message Invalid username or password.

--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -3,7 +3,7 @@ Feature: Series Page
   Scenario: Logged in user selects nothing from dropdown
     Given A logged in user
     When the logged in user navigates to the series page
-    And the user clicks the .govuk-button element
+    And the user clicks the continue button
     Then the logged in user should stay at the series page
     And the user will see a form error message This field is required
 
@@ -17,7 +17,7 @@ Feature: Series Page
   Scenario: Logged in user selects 'back' when on Series page
     Given A logged in user
     When the logged in user navigates to the series page
-    And the user clicks the .govuk-back-link element
+    And the user clicks the Back link
     Then the user should be at the dashboard page
 
   Scenario: User from MOCK1 Department transferring body sees the correct series choices

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -113,12 +113,6 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   }
 
-  And("^the user clicks the (.*) element$") {
-    selector: String =>
-      val clickableElement = webDriver.findElement(By.cssSelector(selector))
-      clickableElement.click()
-  }
-
   Then("^the logged out user should be at the (.*) page") {
     page: String =>
       val currentUrl: String = webDriver.getCurrentUrl
@@ -208,12 +202,6 @@ class Steps extends ScalaDsl with EN with Matchers {
     button.click()
   }
 
-  And("^the user clicks the (.*) checkbox$") {
-    selector: String =>
-      val clickableElement = webDriver.findElement(By.id(selector))
-      clickableElement.click()
-  }
-
   And ("^the user confirms that DRO has signed off on the records") {
     val droAppraisalAndSelection = webDriver.findElement(By.id("droAppraisalSelection"))
     val dropSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
@@ -257,6 +245,11 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the page will redirect to the (.*) page after upload is complete") {
     page: String =>
       val _ = new WebDriverWait(webDriver, 10).until(ExpectedConditions.titleContains(page.capitalize))
+  }
+
+  And("^the user clicks the (.*) link") {
+    linkClicked: String =>
+      webDriver.findElement(By.linkText(linkClicked)).click()
   }
 
   When("^the user selects yes to all transfer agreement checks") {


### PR DESCRIPTION
This also allows for more 'human' readable language used in scenarios and steps. I have removed steps that reference specific element CSS class names etc in favour of text that shows on the user side so that tests are a bit easier to read. Also means we can compare these to acceptance criteria more easily.