### PR TITLE
Test to ensure user can't submit incomplete TA form

### DIFF
--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -5,7 +5,7 @@ Feature: Series Page
     When the logged in user navigates to the series page
     And the user clicks the continue button
     Then the logged in user should stay at the series page
-    And the user will see a form error message This field is required
+    And the user will see a form error message "This field is required"
 
   Scenario: Logged in user selects a series from the dropdown
     Given A logged in user

--- a/src/test/resources/features/TransferAgreement.feature
+++ b/src/test/resources/features/TransferAgreement.feature
@@ -1,13 +1,13 @@
 Feature: Transfer Agreement Page
 
-#  Scenario: A logged in user completes the Transfer Agreement form correctly
-#    Given an existing user
-#    And an existing consignment for transferring body MOCK1 Department
-#    And the user is logged in on the Transfer Agreement page
-#    When the user selects yes to all transfer agreement checks
-#    And the user confirms that DRO has signed off on the records
-#    And the user clicks the continue button
-#    Then the user will be on a page with the title Upload Records
+  Scenario: A logged in user completes the Transfer Agreement form correctly
+    Given an existing user
+    And an existing consignment for transferring body MOCK1 Department
+    And the user is logged in on the Transfer Agreement page
+    When the user selects yes to all transfer agreement checks
+    And the user confirms that DRO has signed off on the records
+    And the user clicks the continue button
+    Then the user will be on a page with the title Upload Records
 
   Scenario: A logged in user submits Transfer Agreement without DRO approval
     Given an existing user

--- a/src/test/resources/features/TransferAgreement.feature
+++ b/src/test/resources/features/TransferAgreement.feature
@@ -8,3 +8,21 @@ Feature: Transfer Agreement Page
     And the user confirms that DRO has signed off on the records
     And the user clicks the continue button
     Then the user will be on a page with the title Upload Records
+
+  Scenario: A logged in user submits Transfer Agreement without DRO approval
+    Given an existing user
+    And an existing consignment for transferring body MOCK1 Department
+    And the user is logged in on the Transfer Agreement page
+    When the user selects yes to all transfer agreement checks
+    And the user does not confirm DRO sign off for the records
+    And the user clicks the continue button
+    Then the user will see a form error message DRO must have signed off the appraisal and selection decision for records
+
+  Scenario: A logged in user submits Transfer Agreement without responding yes to all questions
+    Given an existing user
+    And an existing consignment for transferring body MOCK1 Department
+    And the user is logged in on the Transfer Agreement page
+    When the user selects yes to only some of the transfer agreement checks
+    And the user confirms that DRO has signed off on the records
+    And the user clicks the continue button
+    Then the user will see a form error message All records must be confirmed as digital before proceeding

--- a/src/test/resources/features/TransferAgreement.feature
+++ b/src/test/resources/features/TransferAgreement.feature
@@ -1,13 +1,13 @@
 Feature: Transfer Agreement Page
 
-  Scenario: A logged in user completes the Transfer Agreement form correctly
-    Given an existing user
-    And an existing consignment for transferring body MOCK1 Department
-    And the user is logged in on the Transfer Agreement page
-    When the user selects yes to all transfer agreement checks
-    And the user confirms that DRO has signed off on the records
-    And the user clicks the continue button
-    Then the user will be on a page with the title Upload Records
+#  Scenario: A logged in user completes the Transfer Agreement form correctly
+#    Given an existing user
+#    And an existing consignment for transferring body MOCK1 Department
+#    And the user is logged in on the Transfer Agreement page
+#    When the user selects yes to all transfer agreement checks
+#    And the user confirms that DRO has signed off on the records
+#    And the user clicks the continue button
+#    Then the user will be on a page with the title Upload Records
 
   Scenario: A logged in user submits Transfer Agreement without DRO approval
     Given an existing user
@@ -16,13 +16,13 @@ Feature: Transfer Agreement Page
     When the user selects yes to all transfer agreement checks
     And the user does not confirm DRO sign off for the records
     And the user clicks the continue button
-    Then the user will see a form error message DRO must have signed off the appraisal and selection decision for records
+    Then the user will see a form error message "DRO must have signed off the appraisal and selection decision for records"
 
   Scenario: A logged in user submits Transfer Agreement without responding yes to all questions
     Given an existing user
     And an existing consignment for transferring body MOCK1 Department
     And the user is logged in on the Transfer Agreement page
-    When the user selects yes to only some of the transfer agreement checks
+    When the user selects yes for all checks except "The records are all Digital"
     And the user confirms that DRO has signed off on the records
     And the user clicks the continue button
-    Then the user will see a form error message All records must be confirmed as digital before proceeding
+    Then the user will see a form error message "All records must be confirmed as digital before proceeding"

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -202,10 +202,15 @@ class Steps extends ScalaDsl with EN with Matchers {
     button.click()
   }
 
-  And ("^the user confirms that DRO has signed off on the records") {
+  And("^the user confirms that DRO has signed off on the records") {
     val droAppraisalAndSelection = webDriver.findElement(By.id("droAppraisalSelection"))
     val dropSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
     droAppraisalAndSelection.click()
+    dropSensitivityAndOpen.click()
+  }
+
+  And("^the user does not confirm DRO sign off for the records") {
+    val dropSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
     dropSensitivityAndOpen.click()
   }
 
@@ -250,6 +255,15 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the user clicks the (.*) link") {
     linkClicked: String =>
       webDriver.findElement(By.linkText(linkClicked)).click()
+  }
+
+  When("^the user selects yes to only some of the transfer agreement checks") {
+    val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecordtrue"))
+    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyrighttrue"))
+    val recordsAllEnglish = webDriver.findElement(By.id("englishtrue"))
+    recordsAllPublicRecords.click()
+    recordsAllCrownCopyright.click()
+    recordsAllEnglish.click()
   }
 
   When("^the user selects yes to all transfer agreement checks") {

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -162,7 +162,7 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertEquals(errorMessage, errorElement.getText)
   }
 
-  And("^the user will see a form error message (.*)") {
+  And("^the user will see a form error message \"(.*)\"") {
     formErrorMessage: String =>
       val errorElement = webDriver.findElement(By.cssSelector(".govuk-error-message"))
       Assert.assertNotNull(errorElement)
@@ -202,16 +202,36 @@ class Steps extends ScalaDsl with EN with Matchers {
     button.click()
   }
 
+  When("^the user selects yes for all checks except \"The records are all Digital\"") {
+    val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecordtrue"))
+    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyrighttrue"))
+    val recordsAllEnglish = webDriver.findElement(By.id("englishtrue"))
+    recordsAllPublicRecords.click()
+    recordsAllCrownCopyright.click()
+    recordsAllEnglish.click()
+  }
+
+  When("^the user selects yes to all transfer agreement checks") {
+    val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecordtrue"))
+    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyrighttrue"))
+    val recordsAllEnglish = webDriver.findElement(By.id("englishtrue"))
+    val recordsAllDigital = webDriver.findElement(By.id("digitaltrue"))
+    recordsAllPublicRecords.click()
+    recordsAllCrownCopyright.click()
+    recordsAllEnglish.click()
+    recordsAllDigital.click()
+  }
+
   And("^the user confirms that DRO has signed off on the records") {
     val droAppraisalAndSelection = webDriver.findElement(By.id("droAppraisalSelection"))
-    val dropSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
+    val droSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
     droAppraisalAndSelection.click()
-    dropSensitivityAndOpen.click()
+    droSensitivityAndOpen.click()
   }
 
   And("^the user does not confirm DRO sign off for the records") {
-    val dropSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
-    dropSensitivityAndOpen.click()
+    val droSensitivityAndOpen = webDriver.findElement(By.id("droSensitivity"))
+    droSensitivityAndOpen.click()
   }
 
   And("^an existing consignment for transferring body (.*)") {
@@ -255,25 +275,5 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the user clicks the (.*) link") {
     linkClicked: String =>
       webDriver.findElement(By.linkText(linkClicked)).click()
-  }
-
-  When("^the user selects yes to only some of the transfer agreement checks") {
-    val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecordtrue"))
-    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyrighttrue"))
-    val recordsAllEnglish = webDriver.findElement(By.id("englishtrue"))
-    recordsAllPublicRecords.click()
-    recordsAllCrownCopyright.click()
-    recordsAllEnglish.click()
-  }
-
-  When("^the user selects yes to all transfer agreement checks") {
-    val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecordtrue"))
-    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyrighttrue"))
-    val recordsAllEnglish = webDriver.findElement(By.id("englishtrue"))
-    val recordsAllDigital = webDriver.findElement(By.id("digitaltrue"))
-    recordsAllPublicRecords.click()
-    recordsAllCrownCopyright.click()
-    recordsAllEnglish.click()
-    recordsAllDigital.click()
   }
 }


### PR DESCRIPTION
This change adds test scenarios to make sure that the Transfer Agreement form can only be submitted when completed correctly. This will need updated when we add extra options for the form in future. Fixes TDR-288