### PR TITLE
Change wording of slack message to be more clear

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
         failure {
             script {
                 tdr.postToDaTdrSlackChannel(colour: "danger",
-                                            message: " :warning: *End to End Test Failure*\n *TDR Environment*: ${params.STAGE}\n" +
+                                            message: " :warning: *End to end tests have failed*\n *TDR Environment*: ${params.STAGE}\n" +
                                                      "  *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html"
                 )
             }
@@ -86,7 +86,7 @@ pipeline {
         fixed {
             script {
                 tdr.postToDaTdrSlackChannel(colour: "good",
-                                            message: " :green_heart: *End to End Tests Succeeded*\n *TDR Environment*: ${params.STAGE}\n" +
+                                            message: " :green_heart: *End to end tests have succeeded after previous failure*\n *TDR Environment*: ${params.STAGE}\n" +
                                                      "  *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html"
                 )
             }


### PR DESCRIPTION
The success message has now been changed to make it more clear that it has succeeded after a previous failure. I have also changed the wording of the failure message to match the phrasing of the success message.