### PR TITLE
Remove the click button code as we already have a step for it

### DIFF
--- a/src/test/resources/features/Upload.feature
+++ b/src/test/resources/features/Upload.feature
@@ -12,6 +12,7 @@ Feature: Upload
     And an existing transfer agreement
     And the user is logged in on the upload page
     When the user uploads a file
+    And the user clicks the continue button
     Then the progress bar should be visible
 
   Scenario: The records page is shown when the upload is completed
@@ -20,4 +21,5 @@ Feature: Upload
     And an existing transfer agreement
     And the user is logged in on the upload page
     When the user uploads a file
+    And the user clicks the continue button
     Then the page will redirect to the records page after upload is complete

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -191,7 +191,7 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertTrue(currentUrl.startsWith(s"$baseUrl/$page"))
   }
 
-  And ("^the user selects the series (.*)") {
+  And("^the user selects the series (.*)") {
     selectedSeries: String =>
       val seriesDropdown = new Select(webDriver.findElement(By.name("series")))
       seriesDropdown.selectByVisibleText(selectedSeries)
@@ -253,7 +253,6 @@ class Steps extends ScalaDsl with EN with Matchers {
 
     val input = webDriver.findElement(By.cssSelector("#file-selection"))
     input.sendKeys(s"${System.getProperty("user.dir")}/src/test/resources/testfiles")
-    webDriver.findElement(By.cssSelector(".govuk-button")).click()
   }
 
   Then("^the (.*) should (.*) visible") {


### PR DESCRIPTION
I did this so that the "When("^the user uploads a file")" step is strictly just the act of uploading and then clicking would be the next step, avoiding having two pieces of code in the Steps.scala that find a "continue" button click it