### PR TITLE
Increase upload file size

### DIFF
--- a/src/test/resources/features/Fullflow.feature
+++ b/src/test/resources/features/Fullflow.feature
@@ -16,6 +16,6 @@ Feature: Full user journey
     And the user confirms that DRO has signed off on the records
     And the user clicks the continue button
     Then the user will be on a page with the title Upload Records
-    When the user selects a directory
+    When the user selects directory containing: testfile1
     And the user clicks the continue button
     Then the user will be on a page with the title Records

--- a/src/test/resources/features/Upload.feature
+++ b/src/test/resources/features/Upload.feature
@@ -13,7 +13,7 @@ Feature: Upload
     And an existing consignment for transferring body MOCK1 Department
     And an existing transfer agreement
     And the user is logged in on the upload page
-    When the user selects a directory
+    When the user selects directory containing: largefile
     And the user clicks the continue button
     Then the progress bar should be visible
 
@@ -22,7 +22,7 @@ Feature: Upload
     And an existing consignment for transferring body MOCK1 Department
     And an existing transfer agreement
     And the user is logged in on the upload page
-    When the user selects a directory
+    When the user selects directory containing: testfile1
     And the user clicks the continue button
     Then the user will be on a page with the title Records
 
@@ -31,10 +31,10 @@ Feature: Upload
     And an existing consignment for transferring body MOCK1 Department
     And an existing transfer agreement
     And the user is logged in on the upload page
-    When the user selects a directory
+    When the user selects directory containing: testfile1
     And the user clicks the continue button
     Then the user will be on a page with the title Records
     When the user clicks their browser's back button
-    And the user selects a directory
+    And the user selects directory containing: testfile1
     And the user clicks the continue button
     Then the user should see the upload error message "Upload already occurred for consignment: {consignmentId}"

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -230,14 +230,16 @@ class Steps extends ScalaDsl with EN with Matchers {
     client.createTransferAgreement(consignmentId)
   }
 
-  When("^the user selects a directory") {
-    new WebDriverWait(webDriver, 10).until((driver: WebDriver) => {
-      val executor = driver.asInstanceOf[JavascriptExecutor]
-      executor.executeScript("return AWS.config && AWS.config.credentials && AWS.config.credentials.accessKeyId") != null
-    })
+  When("^the user selects directory containing: (.*)") {
+    (fileName: String) => {
+      new WebDriverWait(webDriver, 10).until((driver: WebDriver) => {
+        val executor = driver.asInstanceOf[JavascriptExecutor]
+        executor.executeScript("return AWS.config && AWS.config.credentials && AWS.config.credentials.accessKeyId") != null
+      })
 
-    val input = webDriver.findElement(By.cssSelector("#file-selection"))
-    input.sendKeys(s"${System.getProperty("user.dir")}/src/test/resources/testfiles/testfile1")
+      val input = webDriver.findElement(By.cssSelector("#file-selection"))
+      input.sendKeys(s"${System.getProperty("user.dir")}/src/test/resources/testfiles/${fileName}")
+    }
   }
 
   Then("^the (.*) should be visible") {


### PR DESCRIPTION
"Progress bar visible" test intermittently failing. Caused by the file upload completing, and page redirect occuring before test completed check for progress bar element. The element was not present on the redirect page, causing the condition to timeout, and the test to fail

Increased the upload file size for the "Progress bar visible" to 10mb. With this size file the test passed 10 times in row during testing