### PR TITLE
Fix file check page name in e2e tests as name changed in TDR FE

### DIFF
--- a/src/test/resources/features/Fullflow.feature
+++ b/src/test/resources/features/Fullflow.feature
@@ -18,4 +18,4 @@ Feature: Full user journey
     Then the user will be on a page with the title Upload Records
     When the user selects directory containing: testfile1
     And the user clicks the continue button
-    Then the user will be on a page with the title Records
+    Then the user will be on a page with the title Checking your records

--- a/src/test/resources/features/Upload.feature
+++ b/src/test/resources/features/Upload.feature
@@ -24,7 +24,7 @@ Feature: Upload
     And the user is logged in on the upload page
     When the user selects directory containing: testfile1
     And the user clicks the continue button
-    Then the user will be on a page with the title Records
+    Then the user will be on a page with the title Checking your records
 
   Scenario: A logged in user tries to upload multiple set of files to a consignment
     Given A logged out user
@@ -33,7 +33,7 @@ Feature: Upload
     And the user is logged in on the upload page
     When the user selects directory containing: testfile1
     And the user clicks the continue button
-    Then the user will be on a page with the title Records
+    Then the user will be on a page with the title Checking your records
     When the user clicks their browser's back button
     And the user selects directory containing: testfile1
     And the user clicks the continue button


### PR DESCRIPTION
This change removes steps describing test user on 'records' page and replaces it with the correct 'Checking your records' page.