### PR TITLE
Update keycloak libraries to 11.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ version := "0.1"
 scalaVersion := "2.13.1"
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
-libraryDependencies += "org.keycloak" % "keycloak-core" % "9.0.0" % Test
-libraryDependencies += "org.keycloak" % "keycloak-admin-client" % "9.0.0" % Test
+libraryDependencies += "org.keycloak" % "keycloak-core" % "11.0.1" % Test
+libraryDependencies += "org.keycloak" % "keycloak-admin-client" % "11.0.1" % Test
 libraryDependencies += "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.12"
 libraryDependencies += "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.48"
 libraryDependencies += "io.circe" %% "circe-core" % "0.13.0"


### PR DESCRIPTION
The e2e tests actually still work on the old libraries but we may as
well keep them up to date.