### PR TITLE
Change step usage to fix unstable tests on Jenkins

### DIFF
--- a/src/test/resources/features/Fullflow.feature
+++ b/src/test/resources/features/Fullflow.feature
@@ -18,8 +18,8 @@ Feature: Full user journey
     Then the user will be on a page with the title "Upload Records"
     When the user selects directory containing: testfile1
     And the user clicks the continue button
-    Then the user will be on a page with the title Checking your records
+    Then the user will be on a page with the title "Checking your records"
     And the user should see the Antivirus Metadata progress bar
-    And the user will be on a page with the title Record check results
+    And the user will be on a page with the title "Record check results"
 
 


### PR DESCRIPTION
Tests needed to have quotation marks ("") around page titles to follow step definition. This was causing Jenkins runs to be unstable.