### PR TITLE
Tdr 414 ffid progress

### DIFF
--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -4,17 +4,19 @@ Feature: File Checks Page
     Given A logged out user
     And an existing consignment for transferring body MOCK1
     And an existing transfer agreement
-    And an existing upload
+    And an existing upload of 5 files
+    And 1 of the antivirus scans have finished
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the av metadata progress bar should be visible
-    And the av metadata progress bar should have 75% progress
+    And the av metadata progress bar should have 20% progress
 
   Scenario: A user will see checksum progress bar on the file checks page
     Given A logged out user
     And an existing consignment for transferring body MOCK1
     And an existing transfer agreement
-    And an existing upload
+    And an existing upload of 4 files
+    And 3 of the checksum scans have finished
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the checksum progress bar should be visible
@@ -24,21 +26,26 @@ Feature: File Checks Page
     Given A logged out user
     And an existing consignment for transferring body MOCK1
     And an existing transfer agreement
-    And an existing upload
+    And an existing upload of 8 files
+    And 2 of the FFID scans have finished
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the ffid progress bar should be visible
-    And the ffid progress bar should have 75% progress
+    And the ffid progress bar should have 25% progress
 
   Scenario: User is redirected to results page when the record checks are complete
     Given A logged out user
     And an existing consignment for transferring body MOCK1
     And an existing transfer agreement
-    And an existing upload
+    And an existing upload of 10 files
+    And 2 of the FFID scans have finished
+    And 5 of the checksum scans have finished
+    And 8 of the antivirus scans have finished
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the user waits for the checks to complete
     Then the user will be on a page with the title "Record check results"
+
   Scenario: User is redirected to the results page if the checks are complete and they visit the record checks page
     Given A logged out user
     And an existing consignment for transferring body MOCK1

--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -20,6 +20,16 @@ Feature: File Checks Page
     And the checksum progress bar should be visible
     And the checksum progress bar should have 25% progress
 
+  Scenario: A user will see FFID progress bar on the file checks page
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    And an existing upload
+    When the user is logged in on the records page
+    Then the user will be on a page with the title "Checking your records"
+    And the ffid progress bar should be visible
+    And the ffid progress bar should have 50% progress
+
 #    This scenario still goes through the upload manually rather than using the helper methods so that the redirect can be tested
   Scenario: User is redirected to results page when the record checks are complete
     Given A logged out user

--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -18,7 +18,7 @@ Feature: File Checks Page
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the checksum progress bar should be visible
-    And the checksum progress bar should have 25% progress
+    And the checksum progress bar should have 75% progress
 
   Scenario: A user will see FFID progress bar on the file checks page
     Given A logged out user
@@ -28,18 +28,17 @@ Feature: File Checks Page
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the ffid progress bar should be visible
-    And the ffid progress bar should have 50% progress
+    And the ffid progress bar should have 75% progress
 
-#    This scenario still goes through the upload manually rather than using the helper methods so that the redirect can be tested
   Scenario: User is redirected to results page when the record checks are complete
     Given A logged out user
     And an existing consignment for transferring body MOCK1
     And an existing transfer agreement
-    And the user is logged in on the upload page
-    When the user selects directory containing: testfile1
-    And the user clicks the continue button
+    And an existing upload
+    When the user is logged in on the records page
+    Then the user will be on a page with the title "Checking your records"
+    And the user waits for the checks to complete
     Then the user will be on a page with the title "Record check results"
-
   Scenario: User is redirected to the results page if the checks are complete and they visit the record checks page
     Given A logged out user
     And an existing consignment for transferring body MOCK1

--- a/src/test/resources/features/Fullflow.feature
+++ b/src/test/resources/features/Fullflow.feature
@@ -21,6 +21,7 @@ Feature: Full user journey
     Then the user will be on a page with the title "Checking your records"
     And the av metadata progress bar should be visible
     And the checksum progress bar should be visible
+    And the ffid progress bar should be visible
     And the user will be on a page with the title "Record check results"
 
 

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -11,6 +11,7 @@ import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => affm}
 import graphql.codegen.AddFiles.{addFiles => af}
 import graphql.codegen.AddTransferAgreement.{AddTransferAgreement => ata}
 import graphql.codegen.GetSeries.{getSeries => gs}
+import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => aff}
 import graphql.codegen.types._
 import helpers.keycloak.UserCredentials
 
@@ -41,12 +42,6 @@ class GraphqlUtility(userCredentials: UserCredentials) {
     client.result(af.document, af.Variables(input)).data.get.addFiles.fileIds
   }
 
-  def createAVMetadata(fileId: UUID): Unit = {
-    val client = new BackendApiClient[aav.Data, aav.Variables]
-    val input = AddAntivirusMetadataInput(fileId, "E2E tests software", "E2E tests software version", "E2E test DB version", "E2E test result", System.currentTimeMillis)
-    client.sendRequest(aav.document, aav.Variables(input))
-  }
-
   def createClientsideMetadata(userCredentials: UserCredentials, fileId: UUID, checksumValue: String): Unit = {
     val client = new UserApiClient[acf.Data, acf.Variables](userCredentials)
     val dummyInstant = Instant.now()
@@ -59,6 +54,12 @@ class GraphqlUtility(userCredentials: UserCredentials) {
       Some(1024),
       dummyInstant.toEpochMilli))
     client.result(acf.document, acf.Variables(input))
+  }
+
+  def createAVMetadata(fileId: UUID): Unit = {
+    val client = new BackendApiClient[aav.Data, aav.Variables]
+    val input = AddAntivirusMetadataInput(fileId, "E2E tests software", "E2E tests software version", "E2E test DB version", "E2E test result", System.currentTimeMillis)
+    client.sendRequest(aav.document, aav.Variables(input))
   }
 
   def createBackendChecksumMetadata(fileId: UUID): Unit = {

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -11,7 +11,6 @@ import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => affm}
 import graphql.codegen.AddFiles.{addFiles => af}
 import graphql.codegen.AddTransferAgreement.{AddTransferAgreement => ata}
 import graphql.codegen.GetSeries.{getSeries => gs}
-import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => aff}
 import graphql.codegen.types._
 import helpers.keycloak.UserCredentials
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -252,9 +252,11 @@ class Steps extends ScalaDsl with EN with Matchers {
 //  75% & 25% progress has been chosen for the AVMetadata & Checksum progress as these are more realistic tests than using 100% or 0%.
     val client = GraphqlUtility(userCredentials)
     val createdFiles: List[UUID] = client.createFiles(consignmentId, 4)
-    createdFiles.foreach(id => client.createClientsideMetadata(userCredentials, id, "checksumValue")) //checksumValue will be replaced with actual checksum soon
+    createdFiles.foreach(id => client.createClientsideMetadata(userCredentials, id, "checksumValue"))
+//  checksumValue will be replaced with actual checksum soon
     createdFiles.drop(1).foreach(id => client.createAVMetadata(id))
     createdFiles.drop(3).foreach(id => client.createBackendChecksumMetadata(id))
+    createdFiles.drop(2).foreach(id => client.createFFIDMetadata(id))
   }
 
   When("^the user selects directory containing: (.*)") {

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -261,16 +261,18 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   And("^(\\d+) of the (.*) scans have finished") {
     val client = GraphqlUtility(userCredentials)
-    (filesProcessed: Int, metadataType: String) => {
-      if (metadataType.contains("antivirus")) {
-        filesWithoutAVMetadata = createdFiles.drop(filesProcessed)
-        createdFiles.slice(0, filesProcessed).foreach(id => client.createAVMetadata(id))
-      } else if (metadataType.contains("FFID")) {
-        createdFiles.slice(0, filesProcessed).foreach(id => client.createFfidMetadata(id))
-        filesWithoutFFIDMetadata = createdFiles.drop(filesProcessed)
-      } else if (metadataType.contains("checksum")) {
-        createdFiles.slice(0, filesProcessed).foreach(id => client.createBackendChecksumMetadata(id))
-        filesWithoutChecksumMetadata = createdFiles.drop(filesProcessed)
+    (filesToProcess: Int, metadataType: String) => {
+      val fileRangeToProcess = createdFiles.slice(0, filesToProcess)
+      metadataType match {
+        case "antivirus" =>
+          fileRangeToProcess.foreach(id => client.createAVMetadata(id))
+          filesWithoutAVMetadata = createdFiles.drop(filesToProcess)
+        case "FFID" =>
+          fileRangeToProcess.foreach(id => client.createFfidMetadata(id))
+          filesWithoutFFIDMetadata = createdFiles.drop(filesToProcess)
+        case "checksum" =>
+          fileRangeToProcess.foreach(id => client.createBackendChecksumMetadata(id))
+          filesWithoutChecksumMetadata = createdFiles.drop(filesToProcess)
       }
     }
   }


### PR DESCRIPTION
These changes add a test scenario for the FFDIMetadata progress bar, with a new GraphqlUtility function to add FFIDMetadata to the appropriate table and, removes the manual upload scenario from the fileChecks scenarios file.

I have added a step to simulate the user waiting for backend checks to complete, to allow us to check that the redirect only happens when all checks are complete and to let us remove the 'manual' test user upload. This functionality is a little clumsy at the moment and definitely needs refactoring, but I was unsure of which direction to go with it.