### PR TITLE
Change user deletion method

### DIFF
--- a/src/test/scala/helpers/keycloak/KeycloakClient.scala
+++ b/src/test/scala/helpers/keycloak/KeycloakClient.scala
@@ -53,7 +53,7 @@ object KeycloakClient {
   }
 
   def deleteUser(userId: String): Unit = {
-    userResource.get(userId).remove
+    userResource.delete(userId)
   }
 }
 


### PR DESCRIPTION
Trying to delete non-existent user was causing errors

This was because trying to retrieve the non-existent user before using the remove method

Changed to using delete method