### PR TITLE
Record checks results tests

### DIFF
--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -44,7 +44,7 @@ Feature: File Checks Page
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the user waits for the checks to complete
-    Then the user will be on a page with the panel title "Checks Completed!"
+    Then the user will be on a page with a panel titled "Checks Completed!"
 
   Scenario: User is redirected to the results page if the checks are complete and they visit the record checks page
     Given A logged out user
@@ -52,7 +52,7 @@ Feature: File Checks Page
     And an existing transfer agreement
     And the records checks are complete
     When the user is logged in on the records page
-    Then the user will be on a page with the panel title "Checks Completed!"
+    Then the user will be on a page with a panel titled "Checks Completed!"
 
   Scenario: Consignment records page is accessed by a logged out user
     Given A logged out user

--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -33,9 +33,6 @@ Feature: File Checks Page
     And the ffid progress bar should be visible
     And the ffid progress bar should have 25% progress
 
-#    @wip temporarily added to stop these tests from running as the upload process being used means the tests fail when trying to go to results page.
-#    The tag will be removed once the uploading process has been changed and tests run successfully again.
-  @wip
   Scenario: User is redirected to results page when the record checks are complete
     Given A logged out user
     And an existing consignment for transferring body MOCK1
@@ -47,16 +44,15 @@ Feature: File Checks Page
     When the user is logged in on the records page
     Then the user will be on a page with the title "Checking your records"
     And the user waits for the checks to complete
-    Then the user will be on a page with the title "Record check results"
+    Then the user will be on a page with the panel title "Checks Completed!"
 
-  @wip
   Scenario: User is redirected to the results page if the checks are complete and they visit the record checks page
     Given A logged out user
     And an existing consignment for transferring body MOCK1
     And an existing transfer agreement
     And the records checks are complete
     When the user is logged in on the records page
-    Then the user will be on a page with the title "Record check results"
+    Then the user will be on a page with the panel title "Checks Completed!"
 
   Scenario: Consignment records page is accessed by a logged out user
     Given A logged out user

--- a/src/test/resources/features/FileChecksResults.feature
+++ b/src/test/resources/features/FileChecksResults.feature
@@ -1,0 +1,25 @@
+Feature: File Checks Results Page
+
+  Scenario: The user logs in to the file checks results page once file checks are complete
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    And the records checks are complete
+    When the user is logged in on the records results page
+    Then the user will be on a page with the panel title "Checks Completed!"
+
+  Scenario: The user will see an error when trying to access file check results for a consignment they don't own
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    And a user who did not create the consignment
+    When the user who did not create the consignment is logged in on the records results page
+    Then the user who did not create the consignment will see the error message "You are not permitted to see this page"
+
+  Scenario: The user will see an error when trying to access file check results before upload has happened
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    When the user is logged in on the records results page
+    Then the user should see a general service error "Sorry, there is a problem with the service"
+

--- a/src/test/resources/features/Fullflow.feature
+++ b/src/test/resources/features/Fullflow.feature
@@ -22,5 +22,3 @@ Feature: Full user journey
     And the av metadata progress bar should be visible
     And the checksum progress bar should be visible
     And the ffid progress bar should be visible
-# The stage to check that the redirect to next page has been removed temporarily while errors are investigated.
-

--- a/src/test/resources/features/RecordsResults.feature
+++ b/src/test/resources/features/RecordsResults.feature
@@ -1,4 +1,4 @@
-Feature: File Checks Results Page
+Feature: Record results Page
 
   Scenario: The user logs in to the file checks results page once file checks are complete
     Given A logged out user
@@ -6,7 +6,7 @@ Feature: File Checks Results Page
     And an existing transfer agreement
     And the records checks are complete
     When the user is logged in on the records results page
-    Then the user will be on a page with the panel title "Checks Completed!"
+    Then the user will be on a page with a panel titled "Checks Completed!"
 
   Scenario: The user will see an error when trying to access file check results for a consignment they don't own
     Given A logged out user

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -33,11 +33,11 @@ class GraphqlUtility(userCredentials: UserCredentials) {
     client.result(ata.document, ata.Variables(input))
   }
 
-  def createFiles(consignmentId: UUID, numberOfFiles: Int): List[UUID] = {
+  def createFiles(consignmentId: UUID, numberOfFiles: Int, parentFolderName: String): List[UUID] = {
     val client = new UserApiClient[af.Data, af.Variables](userCredentials)
-    // I need the new graphql client in here because the API has been updated but this includes changes to the AddFilesInput class
-    // The ticket which changed this is still open so I'll put a placeholder in here until it's time to fix it properly.
-    val input = AddFilesInput(consignmentId, numberOfFiles, Option.empty)
+//    parentFolderName is an option for now, but the API will be changed to take a string rather than Option
+//    Once this happens, this function will be changed to reflect this.
+    val input = AddFilesInput(consignmentId, numberOfFiles, Option(parentFolderName))
     client.result(af.document, af.Variables(input)).data.get.addFiles.fileIds
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -160,6 +160,13 @@ class Steps extends ScalaDsl with EN with Matchers {
       })
   }
 
+  Then("^the user will be on a page with the panel title \"(.*)\"") {
+    panelTitle: String =>
+      val panel = webDriver.findElement(By.className("govuk-panel__title")).getText
+
+      Assert.assertEquals(panelTitle, panel)
+  }
+
   Then("^the user should see a general service error \"(.*)\"") {
     errorMessage: String =>
       val errorElement = webDriver.findElement(By.cssSelector(".govuk-heading-l"))
@@ -253,7 +260,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   And("^the records checks are complete") {
     val client = GraphqlUtility(userCredentials)
-    val createdFiles: List[UUID] = client.createFiles(consignmentId, 1)
+    val createdFiles: List[UUID] = client.createFiles(consignmentId, 1, "E2E TEST UPLOAD FOLDER")
     createdFiles.foreach({
       id => client.createClientsideMetadata(userCredentials, id, "checksumValue")
         client.createAVMetadata(id)
@@ -265,7 +272,7 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^an existing upload of (\\d+) files") {
     val client = GraphqlUtility(userCredentials)
     numberOfFiles: Int => {
-      createdFiles = client.createFiles(consignmentId, numberOfFiles)
+      createdFiles = client.createFiles(consignmentId, numberOfFiles, "E2E TEST UPLOAD FOLDER")
       //  checksumValue will be replaced with actual checksum soon
       createdFiles.foreach(id => client.createClientsideMetadata(userCredentials, id, "checksumValue"))
     }
@@ -383,4 +390,5 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the user navigates to a page that does not exist") {
     loadPage("some-page")
   }
+
 }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -160,7 +160,7 @@ class Steps extends ScalaDsl with EN with Matchers {
       })
   }
 
-  Then("^the user will be on a page with the panel title \"(.*)\"") {
+  Then("^the user will be on a page with a panel titled \"(.*)\"") {
     panelTitle: String =>
       val panel = webDriver.findElement(By.className("govuk-panel__title")).getText
 
@@ -390,5 +390,4 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the user navigates to a page that does not exist") {
     loadPage("some-page")
   }
-
 }


### PR DESCRIPTION
This work adds an E2E test feature file for the fileChecksResults page and fixes existing tests to reflect the addition of this page. 

One of the step functions has been altered to feed in a parent folder name thus allowing us to check the fileChecksResults page since it no longer returns an error. 