### PR TITLE
Change log level and make keycloak client lazy

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <logger name="org.apache" level="ERROR" />
+    <logger name="httpclient" level="ERROR" />
+</configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <logger name="org.apache" level="ERROR" />
-    <logger name="httpclient" level="ERROR" />
-</configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <logger name="org.apache" level="INFO" />
+    <logger name="httpclient" level="INFO" />
+</configuration>

--- a/src/test/scala/helpers/aws/AWSUtility.scala
+++ b/src/test/scala/helpers/aws/AWSUtility.scala
@@ -20,7 +20,7 @@ class AWSUtility {
   lazy val config: Config = ConfigFactory.load
   lazy val httpClient: SdkHttpClient = ApacheHttpClient.builder.build
 
-  lazy val provider: AwsCredentialsProvider with SdkAutoCloseable = if(config.hasPath("s3.role")) {
+  val provider: AwsCredentialsProvider with SdkAutoCloseable = if(config.hasPath("s3.role")) {
     //Assume role if running on Jenkins
     val sts = StsClient.builder()
       .region(Region.EU_WEST_2)
@@ -36,7 +36,7 @@ class AWSUtility {
       .build()
   } else {
     //Otherwise, use local credentials
-    DefaultCredentialsProvider.builder().reuseLastProviderEnabled(false).build()
+    DefaultCredentialsProvider.builder().build()
   }
 
   val s3: S3Client = S3Client.builder()

--- a/src/test/scala/helpers/aws/AWSUtility.scala
+++ b/src/test/scala/helpers/aws/AWSUtility.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 class AWSUtility {
 
   lazy val config: Config = ConfigFactory.load
-  lazy val httpClient: SdkHttpClient = ApacheHttpClient.builder.build
+  lazy val httpClient: SdkHttpClient = ApacheHttpClient.builder.maxConnections().build
 
   lazy val provider: AwsCredentialsProvider with SdkAutoCloseable = if(config.hasPath("s3.role")) {
     //Assume role if running on Jenkins

--- a/src/test/scala/helpers/aws/AWSUtility.scala
+++ b/src/test/scala/helpers/aws/AWSUtility.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 class AWSUtility {
 
   lazy val config: Config = ConfigFactory.load
-  lazy val httpClient: SdkHttpClient = ApacheHttpClient.builder.maxConnections().build
+  lazy val httpClient: SdkHttpClient = ApacheHttpClient.builder.build
 
   lazy val provider: AwsCredentialsProvider with SdkAutoCloseable = if(config.hasPath("s3.role")) {
     //Assume role if running on Jenkins

--- a/src/test/scala/helpers/keycloak/KeycloakClient.scala
+++ b/src/test/scala/helpers/keycloak/KeycloakClient.scala
@@ -19,7 +19,7 @@ object KeycloakClient {
   private val userAdminClient: String = configuration.getString("keycloak.user.admin.client")
   private val userAdminSecret: String = configuration.getString("keycloak.user.admin.secret")
 
-  private val keyCloakAdminClient: Keycloak = KeycloakBuilder.builder()
+  lazy private val keyCloakAdminClient: Keycloak = KeycloakBuilder.builder()
     .serverUrl(s"$authUrl/auth")
     .realm("tdr")
     .clientId(userAdminClient)
@@ -27,8 +27,8 @@ object KeycloakClient {
     .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
     .build()
 
-  private val realm: RealmResource = keyCloakAdminClient.realm("tdr")
-  private val userResource: UsersResource = realm.users()
+  lazy private val realm: RealmResource = keyCloakAdminClient.realm("tdr")
+  lazy private val userResource: UsersResource = realm.users()
 
   def createUser(userCredentials: UserCredentials, body: Option[String] = Some("MOCK1")): String = {
 

--- a/src/test/scala/helpers/keycloak/KeycloakClient.scala
+++ b/src/test/scala/helpers/keycloak/KeycloakClient.scala
@@ -19,7 +19,7 @@ object KeycloakClient {
   private val userAdminClient: String = configuration.getString("keycloak.user.admin.client")
   private val userAdminSecret: String = configuration.getString("keycloak.user.admin.secret")
 
-  lazy private val keyCloakAdminClient: Keycloak = KeycloakBuilder.builder()
+  private def keyCloakAdminClient(): Keycloak = KeycloakBuilder.builder()
     .serverUrl(s"$authUrl/auth")
     .realm("tdr")
     .clientId(userAdminClient)
@@ -27,10 +27,13 @@ object KeycloakClient {
     .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
     .build()
 
-  lazy private val realm: RealmResource = keyCloakAdminClient.realm("tdr")
-  lazy private val userResource: UsersResource = realm.users()
+  private def realmResource(client: Keycloak): RealmResource = client.realm("tdr")
+  private def userResource(realm: RealmResource): UsersResource = realm.users()
 
   def createUser(userCredentials: UserCredentials, body: Option[String] = Some("MOCK1")): String = {
+    val client = keyCloakAdminClient()
+    val realm = realmResource(client)
+    val user = userResource(realm)
 
     val userRepresentation: UserRepresentation = new UserRepresentation
 
@@ -47,13 +50,20 @@ object KeycloakClient {
     body.foreach(b => userRepresentation.setAttributes(Map("body" -> List(b).asJava).asJava))
     userRepresentation.setRealmRoles(List("tdr_user").asJava)
 
-    val response: Response = userResource.create(userRepresentation)
+    val response: Response = user.create(userRepresentation)
 
-    response.getLocation.getPath.replaceAll(".*/([^/]+)$", "$1")
+    val path = response.getLocation.getPath.replaceAll(".*/([^/]+)$", "$1")
+    client.close()
+    path
   }
 
   def deleteUser(userId: String): Unit = {
-    userResource.delete(userId)
+    val client = keyCloakAdminClient()
+    val realm = realmResource(client)
+    val user = userResource(realm)
+
+    user.delete(userId)
+    client.close()
   }
 }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -296,12 +296,12 @@ class Steps extends ScalaDsl with EN with Matchers {
     numberOfFiles: Int => {
       createdFiles = client.createFiles(consignmentId, numberOfFiles, "E2E TEST UPLOAD FOLDER")
       //  checksumValue will be replaced with actual checksum soon
-      val files = List("largefile", "testfile1", "testfile2")
+      val files = List("testfile1", "testfile2")
 
       createdFiles.zipWithIndex.foreach {
         case (id, idx) =>
           client.createClientsideMetadata(userCredentials, id, "checksumValue", idx)
-          val path = Paths.get(s"${System.getProperty("user.dir")}/src/test/resources/testfiles/${files(idx % 3)}")
+          val path = Paths.get(s"${System.getProperty("user.dir")}/src/test/resources/testfiles/${files(idx % 2)}")
           val awsUtility = AWSUtility()
           awsUtility.uploadFileToS3(configuration.getString("s3.bucket.upload"), s"$consignmentId/$id", path)
       }


### PR DESCRIPTION
It looks like this was failing because the apache http client was running out of threads in the pool. I think this is because we're creating a new keycloak client for every user which is wasteful anyway so I've changed these to lazy vals, so they'll only be created on first use.
We probably will encounter some problems later with these values being cached but for now, this is working.
