### PR TITLE
Update series error test with new text and error

### DIFF
--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -5,8 +5,8 @@ Feature: Series Page
     When the logged in user navigates to the series page
     And the user clicks the continue button
     Then the user will remain on the series page
-    And the user will see a form error message "You must select a series"
-    And the user will see a summary error message "You must select a series"
+    And the user will see a form error message "Select a series reference"
+    And the user will see a summary error message "Select a series reference"
 
   Scenario: Logged in user selects a series from the dropdown
     Given A logged in user

--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -5,7 +5,8 @@ Feature: Series Page
     When the logged in user navigates to the series page
     And the user clicks the continue button
     Then the user will remain on the series page
-    And the user will see a form error message "This field is required"
+    And the user will see a form error message "You must select a series"
+    And the user will see a summary error message "You must select a series"
 
   Scenario: Logged in user selects a series from the dropdown
     Given A logged in user

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -210,6 +210,13 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertEquals(s"Error:\n" + formErrorMessage, errorElement.getText)
   }
 
+  And("^the user will see a summary error message \"(.*)\"") {
+    formErrorMessage: String =>
+      val errorElement = webDriver.findElement(By.cssSelector(".govuk-error-summary__list a"))
+      Assert.assertNotNull(errorElement)
+      Assert.assertEquals(formErrorMessage, errorElement.getText)
+  }
+
   Then("^the user should see the series dropdown values (.*)") {
     expectedValues: String =>
       val seriesList: List[String] = expectedValues.split(",").toList

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -211,10 +211,10 @@ class Steps extends ScalaDsl with EN with Matchers {
   }
 
   And("^the user will see a summary error message \"(.*)\"") {
-    formErrorMessage: String =>
+    summaryErrorMessage: String =>
       val errorElement = webDriver.findElement(By.cssSelector(".govuk-error-summary__list a"))
       Assert.assertNotNull(errorElement)
-      Assert.assertEquals(formErrorMessage, errorElement.getText)
+      Assert.assertEquals(summaryErrorMessage, errorElement.getText)
   }
 
   Then("^the user should see the series dropdown values (.*)") {


### PR DESCRIPTION
The front end has been updated to add an error summary element and to
change the wording of the error summary.
This test has been updated to check for the correct new text and check
for the new element.
