### PR TITLE
Set an empty result so the AV shows as passed

### DIFF
--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -55,7 +55,7 @@ class GraphqlUtility(userCredentials: UserCredentials) {
 
   def createAVMetadata(fileId: UUID): Unit = {
     val client = new BackendApiClient[aav.Data, aav.Variables]
-    val input = AddAntivirusMetadataInput(fileId, "E2E tests software", "E2E tests software version", "E2E test DB version", "E2E test result", System.currentTimeMillis)
+    val input = AddAntivirusMetadataInput(fileId, "E2E tests software", "E2E tests software version", "E2E test DB version", "", System.currentTimeMillis)
     client.sendRequest(aav.document, aav.Variables(input))
   }
 


### PR DESCRIPTION
* The test that was waiting for the export to complete was failing.
* The export was failing because I recently deployed the change to fail if there are no files returned for the consignment.
* The API only returns files which have passed the antivirus.
* The method in the e2e tests which creates the dummy results for the AV checks populates the Result field.
* If the Result field is anything other than empty string, it counts as an AV failure and the API won't return the files and so the export won't pass.
