### PR TITLE
Add test for the error summary.

### DIFF
--- a/src/test/resources/features/TransferAgreement.feature
+++ b/src/test/resources/features/TransferAgreement.feature
@@ -19,6 +19,7 @@ Feature: Transfer Agreement Page
     And the user does not confirm DRO sign off for the records
     And the user clicks the continue button
     Then the user will see a form error message "DRO must have signed off the appraisal and selection decision for records"
+    Then the user will see a summary error message "DRO must have signed off the appraisal and selection decision for records"
 
   Scenario: A logged in user submits Transfer Agreement without responding yes to all questions
     Given A logged out user
@@ -29,6 +30,7 @@ Feature: Transfer Agreement Page
     And the user confirms that DRO has signed off on the records
     And the user clicks the continue button
     Then the user will see a form error message "All records must be confirmed as English language before proceeding"
+    Then the user will see a summary error message "All records must be confirmed as English language before proceeding"
 
   Scenario: Consignment transfer agreement page is accessed by a logged out user
     Given A logged out user


### PR DESCRIPTION
We are adding the error summary to the transfer agreement page, this test checks that it's there.
