### PR TITLE
Remove test for Back link on series page

### DIFF
--- a/src/test/resources/features/Series.feature
+++ b/src/test/resources/features/Series.feature
@@ -15,12 +15,6 @@ Feature: Series Page
     And the user clicks the continue button
     Then the user should be on the transfer-agreement page
 
-  Scenario: Logged in user selects 'back' when on Series page
-    Given A logged in user
-    When the logged in user navigates to the series page
-    And the user clicks the Back link
-    Then the user should be on the dashboard page
-
   Scenario: User from MOCK1 transferring body sees the correct series choices
    Given A logged in user who is a member of MOCK1 transferring body
    When the logged in user navigates to the series page

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -392,11 +392,6 @@ class Steps extends ScalaDsl with EN with Matchers {
     }
   }
 
-  And("^the user clicks the (.*) link") {
-    linkToClick: String =>
-      webDriver.findElement(By.linkText(linkToClick)).click()
-  }
-
   When("^the user clicks their browser's back button") {
     webDriver.navigate().back()
   }


### PR DESCRIPTION
This link was removed from the frontend: https://github.com/nationalarchives/tdr-transfer-frontend/pull/444