### PR TITLE
Change the way we check if the previous build failed.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,8 +102,6 @@ pipeline {
         )
       }
     }
-
-
     success {
       script {
         if(getPreviousResultForStage(currentBuild.previousBuild) == "FAILURE") {
@@ -118,9 +116,9 @@ pipeline {
 }
 
 def getPreviousResultForStage(runWrapper) {
-    if(runWrapper.rawBuild.getEnvironment().get("STAGE") == params.STAGE) {
-        return runWrapper.getResult()
-    } else {
-        getPreviousResultForStage(runWrapper.previousBuild)
-    }
+  if(runWrapper.rawBuild.getEnvironment().get("STAGE") == params.STAGE) {
+    return runWrapper.getResult()
+  } else {
+    getPreviousResultForStage(runWrapper.previousBuild)
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,13 +102,25 @@ pipeline {
         )
       }
     }
-    fixed {
+
+
+    success {
       script {
-        tdr.postToDaTdrSlackChannel(colour: "good",
-                      message: " :green_heart: *End to end tests have succeeded after previous failure*\n *TDR Environment*: ${params.STAGE}\n" +
-                                                  "  *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html"
-        )
+        if(getPreviousResultForStage(currentBuild.previousBuild) == "FAILURE") {
+          tdr.postToDaTdrSlackChannel(colour: "good",
+                                message: " :green_heart: *End to end tests have succeeded after previous failure*\n *TDR Environment*: ${params.STAGE}\n" +
+                                                            "  *Deploy Job*: ${DEPLOY_JOB_URL} \n *Cucumber report*: ${BUILD_URL}cucumber-html-reports/overview-features.html"
+                  )
+        }
       }
     }
   }
+}
+
+def getPreviousResultForStage(runWrapper) {
+    if(runWrapper.rawBuild.getEnvironment().get("STAGE") == params.STAGE) {
+        return runWrapper.getResult()
+    } else {
+        getPreviousResultForStage(runWrapper.previousBuild)
+    }
 }


### PR DESCRIPTION
We were using fixed in the post block but this would fire if the previous test run was for staging which failed and then the next test run for integration started working which isn't what we want.

This now moves recursively through the previous builds until it finds the previous one with the same stage as the current build and then returns that status.
