### PR TITLE
Add transfer summary test consignment reference

### DIFF
--- a/src/test/resources/features/TransferSummary.feature
+++ b/src/test/resources/features/TransferSummary.feature
@@ -30,7 +30,7 @@ Feature: Transfer Summary Page
     And the user is logged in on the Transfer Summary page
     When the user will be on a page with the title "Transfer Summary"
     Then the transfer summary page shows the user that 4 files have been uploaded
-    And the user should see 4 rows of transfer summary data
+    And the user sees a transfer summary with related information
 
   Scenario: A logged in user submits Final Transfer Confirmation form without confirming anything
     Given A logged out user

--- a/src/test/resources/features/TransferSummary.feature
+++ b/src/test/resources/features/TransferSummary.feature
@@ -23,6 +23,15 @@ Feature: Transfer Summary Page
     When the user will be on a page with the title "Transfer summary"
     Then the transfer summary page shows the user that 3 files have been uploaded
 
+  Scenario: Transfer summary will show all summary information
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing upload of 4 files
+    And the user is logged in on the Transfer Summary page
+    When the user will be on a page with the title "Transfer Summary"
+    Then the transfer summary page shows the user that 4 files have been uploaded
+    And the user should see 4 rows of transfer summary data
+
   Scenario: A logged in user submits Final Transfer Confirmation form without confirming anything
     Given A logged out user
     And an existing consignment for transferring body MOCK1

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -20,7 +20,6 @@ import org.openqa.selenium.support.ui.{FluentWait, Select, WebDriverWait}
 import org.openqa.selenium.{By, JavascriptExecutor, StaleElementReferenceException, WebDriver, WebElement}
 import org.scalatest.Matchers
 
-import scala.collection.convert.ImplicitConversions.`list asScalaBuffer`
 import scala.jdk.CollectionConverters._
 
 class Steps extends ScalaDsl with EN with Matchers {
@@ -484,7 +483,7 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the user should see (.*) rows of transfer summary data") {
     listNumber: Int => {
       val listRows: util.List[WebElement] = webDriver.findElements(By.cssSelector(".govuk-summary-list__key"))
-      Assert.assertEquals(listRows.length, listNumber)
+      Assert.assertEquals(listRows.size, listNumber)
     }
   }
 }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -20,6 +20,7 @@ import org.openqa.selenium.support.ui.{FluentWait, Select, WebDriverWait}
 import org.openqa.selenium.{By, JavascriptExecutor, StaleElementReferenceException, WebDriver, WebElement}
 import org.scalatest.Matchers
 
+import scala.collection.convert.ImplicitConversions.`list asScalaBuffer`
 import scala.jdk.CollectionConverters._
 
 class Steps extends ScalaDsl with EN with Matchers {
@@ -477,6 +478,13 @@ class Steps extends ScalaDsl with EN with Matchers {
       val summaryText = summary.getText
       val expectedText = s"$numberOfFilesUploaded files uploaded"
       Assert.assertTrue(doesNotContain(summaryText, expectedText), summaryText.contains(expectedText))
+    }
+  }
+
+  And("^the user should see (.*) rows of transfer summary data") {
+    listNumber: Int => {
+      val listRows: util.List[WebElement] = webDriver.findElements(By.cssSelector(".govuk-summary-list__key"))
+      Assert.assertEquals(listRows.length, listNumber)
     }
   }
 }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -491,22 +491,23 @@ class Steps extends ScalaDsl with EN with Matchers {
       "Transferring body",
       "Files uploaded for transfer"
     )
-    val transferSummary = webDriver.findElement(By.cssSelector(".govuk-summary-list"))
+    val cssSelector = ".govuk-summary-list"
+    val transferSummaryElement = webDriver.findElement(By.cssSelector(cssSelector))
     val transferSummaryKeys: List[WebElement] = webDriver.findElements(By.cssSelector(".govuk-summary-list__key")).toScalaList
     val transferSummaryValues: List[WebElement] = webDriver.findElements(By.cssSelector(".govuk-summary-list__value")).toScalaList
 
-    Assert.assertNotNull(transferSummary)
+    Assert.assertNotNull(elementMissingMessage(cssSelector), transferSummaryElement)
 
     Assert.assertTrue(transferSummaryKeys.size == 4)
     transferSummaryKeys.forEach(key => {
      val keyText = key.getText
-      Assert.assertTrue("Error: Transfer summary list key empty", !keyText.isEmpty)
-      Assert.assertTrue("Error: Transfer summary list key is incorrect",expectedKeys.contains(keyText))
+      Assert.assertTrue("Transfer summary list key empty", !keyText.isEmpty)
+      Assert.assertTrue("Transfer summary list key is incorrect",expectedKeys.contains(keyText))
     })
 
     Assert.assertTrue(transferSummaryValues.size == 4)
     transferSummaryValues.foreach(value => {
-      Assert.assertTrue("Error: Transfer summary list value empty", !value.getText.isEmpty)
+      Assert.assertTrue("Transfer summary list value empty", !value.getText.isEmpty)
     })
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -1,10 +1,5 @@
 package steps
 
-import java.nio.file.Paths
-import java.time.Duration
-import java.util
-import java.util.UUID
-
 import com.typesafe.config.{Config, ConfigFactory}
 import cucumber.api.scala.{EN, ScalaDsl}
 import helpers.aws.AWSUtility
@@ -17,9 +12,13 @@ import helpers.steps.StepsUtility.calculateTestFileChecksum
 import helpers.users.RandomUtility
 import org.junit.Assert
 import org.openqa.selenium.support.ui.{FluentWait, Select, WebDriverWait}
-import org.openqa.selenium.{By, JavascriptExecutor, StaleElementReferenceException, WebDriver, WebElement}
+import org.openqa.selenium._
 import org.scalatest.Matchers
 
+import java.nio.file.Paths
+import java.time.Duration
+import java.util
+import java.util.UUID
 import scala.jdk.CollectionConverters._
 
 class Steps extends ScalaDsl with EN with Matchers {
@@ -480,10 +479,14 @@ class Steps extends ScalaDsl with EN with Matchers {
     }
   }
 
-  And("^the user should see (.*) rows of transfer summary data") {
-    listNumber: Int => {
-      val listRows: util.List[WebElement] = webDriver.findElements(By.cssSelector(".govuk-summary-list__key"))
-      Assert.assertEquals(listRows.size, listNumber)
-    }
+  And("^the user sees a transfer summary with related information") {
+    val transferSummary: WebElement = webDriver.findElement(By.cssSelector(".govuk-summary-list"))
+
+    Assert.assertNotNull(transferSummary)
+    Assert.assertTrue(transferSummary.getText.contains("MOCK1 123"))
+    Assert.assertTrue(transferSummary.getText.contains("TDR-2021-"))
+    Assert.assertTrue(transferSummary.getText.contains("MOCK1 Department"))
+    Assert.assertTrue(transferSummary.getText.contains("4 files uploaded"))
   }
+
 }


### PR DESCRIPTION
These changes add a scenario and associated steps function to the E2E tests to ensure all expected information is shown within the transfer summary table. I first attempted to check the values of each transfer summary row, but these can vary (specifically the consignment reference) so specific values cannot be expected.

This is why this is a relatively simple addition to the E2E tests, but we can still update if we add more information to the transfer summary list (by increasing the number of rows we expect within the table).