### PR TITLE
Added a check for the upload in progress page

### DIFF
--- a/src/test/resources/features/Upload.feature
+++ b/src/test/resources/features/Upload.feature
@@ -35,9 +35,7 @@ Feature: Upload
     And the user clicks the continue button
     Then the user will be on a page with the title "Checking records"
     When the user clicks their browser's back button
-    And the user selects directory containing: testfile1
-    And the user clicks the continue button
-    Then the user should see the upload error message "Upload already occurred for consignment: {consignmentId}"
+    Then the user should be on the upload-in-progress page
 
   Scenario: Consignment upload page is accessed by a logged out user
     Given A logged out user

--- a/src/test/resources/features/Upload.feature
+++ b/src/test/resources/features/Upload.feature
@@ -35,7 +35,7 @@ Feature: Upload
     And the user clicks the continue button
     Then the user will be on a page with the title "Checking records"
     When the user clicks their browser's back button
-    Then the user should be on the upload-in-progress page
+    Then the user should see the error Your upload was interrupted and could not be completed.
 
   Scenario: Consignment upload page is accessed by a logged out user
     Given A logged out user

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -511,4 +511,16 @@ class Steps extends ScalaDsl with EN with Matchers {
     })
   }
 
+  Then("^the user should see the error (.*)") {
+    errorMessage: String => {
+      val selector = s"//p[contains(text(), '$errorMessage')]"
+      val error = webDriver.findElement(By.xpath(selector))
+      Assert.assertNotNull(elementMissingMessage(selector), error)
+
+      val summaryText = error.getText
+      val expectedText = errorMessage
+      Assert.assertTrue(doesNotContain(summaryText, expectedText), summaryText.contains(expectedText))
+    }
+  }
+
 }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -522,5 +522,4 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertTrue(doesNotContain(summaryText, expectedText), summaryText.contains(expectedText))
     }
   }
-
 }


### PR DESCRIPTION
Originally, you could try to upload two sets of files. Now, there's a
change so that if one upload is in progress, you're redirected to an
error page. This change reflects that.
