### PR TITLE
Add tests for the records errors

### DIFF
--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -68,4 +68,4 @@ Feature: File Checks Page
     And an existing transfer agreement
     And the checksum check has failed
     When the user is logged in on the records page
-    Then the user will see the error summary One or more files you uploaded have failed our checks
+    Then the user will see the error summary "One or more files you uploaded have failed our checks"

--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -61,3 +61,11 @@ Feature: File Checks Page
     And an existing upload of 5 files
     And the logged out user attempts to access the records page
     Then the logged out user should be on the login page
+
+  Scenario: The user will see an error when there is a checksum mismatch
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    And the checksum check has failed
+    When the user is logged in on the records page
+    Then the user will see the error summary One or more files you uploaded have failed our checks

--- a/src/test/resources/features/RecordsResults.feature
+++ b/src/test/resources/features/RecordsResults.feature
@@ -23,3 +23,10 @@ Feature: Record results Page
     When the user is logged in on the records results page
     Then the user should see a general service error "Sorry, there is a problem with the service"
 
+  Scenario: The user will see an error when trying to access file check results when there is a checksum mismatch
+    Given A logged out user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    And the checksum check has failed
+    When the user is logged in on the records results page
+    Then the user will see the error summary One or more files you uploaded have failed our checks

--- a/src/test/resources/features/RecordsResults.feature
+++ b/src/test/resources/features/RecordsResults.feature
@@ -29,4 +29,4 @@ Feature: Record results Page
     And an existing transfer agreement
     And the checksum check has failed
     When the user is logged in on the records results page
-    Then the user will see the error summary One or more files you uploaded have failed our checks
+    Then the user will see the error summary "One or more files you uploaded have failed our checks"

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -232,7 +232,7 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertEquals(errorMessage, errorElement.getText)
   }
 
-  And("^the user will see the error summary (.*)") {
+  And("^the user will see the error summary \"(.*)\"") {
     errorMessage: String =>
       val selector = ".govuk-error-summary__body"
       val errorElement = webDriver.findElement(By.cssSelector(selector))

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -232,6 +232,14 @@ class Steps extends ScalaDsl with EN with Matchers {
       Assert.assertEquals(errorMessage, errorElement.getText)
   }
 
+  And("^the user will see the error summary (.*)") {
+    errorMessage: String =>
+      val selector = ".govuk-error-summary__body"
+      val errorElement = webDriver.findElement(By.cssSelector(selector))
+      Assert.assertNotNull(elementMissingMessage(selector), errorElement)
+      Assert.assertTrue(errorElement.getText.contains(errorMessage))
+  }
+
   And("^the user will see a form error message \"(.*)\"") {
     formErrorMessage: String =>
       val selector = ".govuk-error-message"
@@ -339,6 +347,16 @@ class Steps extends ScalaDsl with EN with Matchers {
         client.createBackendChecksumMetadata(id, checksumValue)
         client.createFfidMetadata(id)
     })
+  }
+
+  And("^the checksum check has failed") {
+    val client = GraphqlUtility(userCredentials)
+    val id: UUID = client.createFiles(consignmentId, 1, "E2E TEST UPLOAD FOLDER").head
+    val checksumValue = createdFilesIdToChecksum.get(id)
+    client.createClientsideMetadata(userCredentials, id, checksumValue, 0)
+    client.createAVMetadata(id)
+    client.createBackendChecksumMetadata(id, Option("mismatchedchecksumvalue"))
+    client.createFfidMetadata(id)
   }
 
   And("^an existing upload of (\\d+) files") {


### PR DESCRIPTION
There's a test to make sure the records page redirects to the error page when there is a checksum error and a check to make sure the record check success message page redirects to the error message if there's an error.