### PR TITLE
Add timeout for checking that file check link has been enabled

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -469,7 +469,9 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the (.*) button should be enabled") {
     (targetIdName: String) => {
       val id = targetIdName.replaceAll(" ", "-")
-      Assert.assertFalse(StepsUtility.elementHasClassDisabled(id, webDriver))
+      new WebDriverWait(webDriver, 2).ignoring(classOf[AssertionError]).until((driver: WebDriver) => {
+        Assert.assertFalse(StepsUtility.elementHasClassDisabled(id, webDriver))
+      })
     }
   }
 


### PR DESCRIPTION
This step was failing on staging. We think it might be because Cucumber is checking the button state as soon as the banner appears, but it might be running so fast that it catches the page in the intermediate state when the button hasn't been enabled yet.

This change will force it to wait 2 seconds before failing.