### PR TITLE
Increase timeout in test of authorisation error

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -510,7 +510,7 @@ class Steps extends ScalaDsl with EN with Matchers {
   Then("^the user who did not create the consignment will see the error message \"(.*)\"") {
     errorMessage: String =>
       val selector = ".govuk-heading-l"
-       new WebDriverWait(webDriver, 2).ignoring(classOf[AssertionError]).until((driver: WebDriver) => {
+       new WebDriverWait(webDriver, 10).ignoring(classOf[AssertionError]).until((driver: WebDriver) => {
          val errorElement = webDriver.findElement(By.cssSelector(selector))
          Assert.assertNotNull(elementMissingMessage(selector), errorElement)
 


### PR DESCRIPTION
The 2 second timeout was too short on some people's dev environments, so increase it to 10 seconds. The wait should still be short if the test passes, so this shouldn't slow down most end-to-end test runs.