### PR TITLE
Increase wait for file check results button

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -477,7 +477,7 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("^the (.*) button should be enabled") {
     (targetIdName: String) => {
       val id = targetIdName.replaceAll(" ", "-")
-      new WebDriverWait(webDriver, 2).ignoring(classOf[AssertionError]).until((driver: WebDriver) => {
+      new WebDriverWait(webDriver, 25).ignoring(classOf[AssertionError]).until((driver: WebDriver) => {
         Assert.assertFalse(StepsUtility.elementHasClassDisabled(id, webDriver))
       })
     }


### PR DESCRIPTION
The file check API call now runs every 20 seconds rather than every 2 seconds, so we need to wait for longer to make sure the Continue button appears: https://github.com/nationalarchives/tdr-transfer-frontend/pull/833