### PR TITLE
Increase timeout on upload page.

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -436,7 +436,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   When("^the user selects directory containing: (.*)") {
     fileName: String => {
-      new WebDriverWait(webDriver, 10).until((driver: WebDriver) => {
+      new WebDriverWait(webDriver, 30).until((driver: WebDriver) => {
         val executor = driver.asInstanceOf[JavascriptExecutor]
         executor.executeScript("return AWS.config && AWS.config.credentials && AWS.config.credentials.accessKeyId") != null
       })


### PR DESCRIPTION
The AWS.config.credentials are now set after the call to the cookies
endpoint. This endpoint can be quite slow, sometimes taking more than 10
seconds if it has to cold start so I've increased the timeout here to
try to stop this failing.

This step passed on another test in the same run so it does work, it
just times out sometimes.
