### PR TITLE
Add tests for judgment dashboard

### DIFF
--- a/src/test/resources/features/Dashboard.feature
+++ b/src/test/resources/features/Dashboard.feature
@@ -4,3 +4,13 @@ Feature: Dashboard Page
     Given A logged out user
     And the logged out user attempts to access the dashboard page
     Then the logged out user should be on the login page
+
+  Scenario: Dashboard page is accessed by a standard user
+    Given A logged in standard user
+    And the logged in user navigates to the dashboard page
+    Then the user will be on a page with a heading "Upload your records to start a new transfer"
+
+  Scenario: Dashboard page is accessed by a judgment user
+    Given A logged in judgment user
+    And the logged in user navigates to the dashboard page
+    Then the user will be on a page with a heading "Upload your judgment to start a new transfer"

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -116,6 +116,12 @@ class Steps extends ScalaDsl with EN with Matchers {
     login(userCredentials)
   }
 
+  Given("^A logged in (.*) user") {
+    userType: String =>
+      userId = KeycloakClient.createUser(userCredentials, userType = Some(userType))
+      login(userCredentials)
+  }
+
   And("^the user is logged in on the (.*) page") {
     page: String =>
       loadPage(page)
@@ -200,6 +206,11 @@ class Steps extends ScalaDsl with EN with Matchers {
   Then("^the user will be on a page with a panel titled \"(.*)\"") {
     panelTitle: String =>
       StepsUtility.waitForElementTitle(webDriver, panelTitle, "govuk-panel__title")
+  }
+
+  Then("^the user will be on a page with a heading \"(.*)\"") {
+    heading: String =>
+      StepsUtility.waitForElementTitle(webDriver, heading, "govuk-heading-m")
   }
 
   Then("^the user will be on a page with a banner titled \"(.*)\"") {


### PR DESCRIPTION
Depending on the 'user type' of the user they will see a different version of the dashboard

This is to support court judgment transfers which will require a different UI and flow from the standard transfer