### PR TITLE
Add a test for the judgment file check results.

### DIFF
--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -41,3 +41,12 @@ Feature: File Checks Page
     And an existing upload of 5 files
     And the logged out user attempts to access the records page
     Then the logged out user should be on the login page
+
+  Scenario: A judgment user should see the judgments file checks progress page
+    Given A logged in judgment user
+    And an existing consignment for transferring body MOCK1
+    And an existing transfer agreement
+    And an existing upload of 5 files
+    And 1 of the antivirus scans have finished
+    When the logged in user navigates to the records page
+    Then the user will be on a page with the title "Checking court judgment record"

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -26,6 +26,7 @@ import scala.jdk.CollectionConverters._
 class Steps extends ScalaDsl with EN with Matchers {
   var webDriver: WebDriver = _
   var userId: String = ""
+  var userType: String = ""
   var differentUserId: String = ""
   var consignmentId: UUID = _
   var createdFiles: List[UUID] = _
@@ -66,9 +67,10 @@ class Steps extends ScalaDsl with EN with Matchers {
   }
 
   private def loadPage(page: String): Unit = {
+    val path = if(userType == "judgment") "judgment" else "consignment"
     val pageWithConsignment = page match {
       case "dashboard" | "series" | "some-page" => s"$baseUrl/$page"
-      case _ => s"$baseUrl/consignment/$consignmentId/${page.toLowerCase.replaceAll(" ", "-")}"
+      case _ => s"$baseUrl/$path/$consignmentId/${page.toLowerCase.replaceAll(" ", "-")}"
     }
     webDriver.get(pageWithConsignment)
   }
@@ -120,6 +122,7 @@ class Steps extends ScalaDsl with EN with Matchers {
     userType: String =>
       userId = KeycloakClient.createUser(userCredentials, userType = Some(userType))
       login(userCredentials)
+      this.userType = userType
   }
 
   And("^the user is logged in on the (.*) page") {


### PR DESCRIPTION
This only checks for the correct title text. The rest of the page and
the javascript is the same as the standard user page so there's no need
to duplicate the tests.
