### PR TITLE
Reset 'userType' after each scenario

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -76,6 +76,7 @@ class Steps extends ScalaDsl with EN with Matchers {
   }
 
   private def userCleanUp(): Unit = {
+    this.userType = ""
     KeycloakClient.deleteUser(userId)
 
     //Not all scenarios create the different user


### PR DESCRIPTION
Ensure 'userType' is reset otherwise incorrect 'path' is generated for tests causing failures