### PR TITLE
Remove the cache action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: coursier/cache-action@v6
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
This is now failing on every run of the tests. I'm not sure why so I'll
remove it for now.

If this massively slows down the tests, we can try to put it back.
