### PR TITLE
Remove redundant steps

### DIFF
--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -69,5 +69,4 @@ Feature: File Checks Page
     And 1 of the checksum scans for the judgment transfer have finished
     And 1 of the antivirus scans for the judgment transfer have finished
     Then the user will be on a page with the title "Checking your upload"
-    And the user waits for the checks to complete
     Then the user will be on a page with the title "Results of checks"

--- a/src/test/resources/features/Upload.feature
+++ b/src/test/resources/features/Upload.feature
@@ -52,8 +52,6 @@ Feature: Upload
   Scenario: The judgment's file checks page is shown when the upload is completed
     Given A logged out judgment user
     And an existing judgment consignment for transferring body MOCK1
-    And an existing private beta transfer agreement
-    And an existing compliance transfer agreement
     And the user is logged in on the upload page
     When the user selects the file: testdocxfile.docx
     And the user clicks the continue button


### PR DESCRIPTION
1. Remove step that was attempting to add metadata to the remaining files, of which there were none, since judgments
only have one file to apply metadata to.
2. Remove the need for an existing TA from the judgments upload scenario as the judgments flow does not have a TA.