### PR TITLE
Put the concurrency back in.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ permissions:
   contents: read
 jobs:
   setup-e2e-tests:
+    concurrency: ${{ github.event.inputs.environment != '' && github.event.inputs.environment || 'intg' }}
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.generate-files.outputs.files }}


### PR DESCRIPTION
We're hitting the limit on the number of rules a security group can have
because these tests are running at the same time on the same
environment.

This should only allow one set of tests to run per environment now. If
this starts taking for ever with the pull request tests then we can
rethink it but this is the only thing I can think of to stop them
failing all the time now.
