### PR TITLE
Get secrets from SSM

### DIFF
--- a/.github/scripts/get_keycloak_secrets.py
+++ b/.github/scripts/get_keycloak_secrets.py
@@ -1,0 +1,23 @@
+import sys
+import boto3
+
+is_pr = len(sys.argv) == 1
+env = "intg" if is_pr else sys.argv[1]
+
+
+def get_client_secret(client_secret_path):
+    ssm_client = boto3.client("ssm")
+    response = ssm_client.get_parameter(
+        Name=client_secret_path,
+        WithDecryption=True
+    )
+    return response["Parameter"]["Value"]
+
+
+user_admin_secret = get_client_secret(f"/{env}/keycloak/user_admin_client/secret")
+backend_checks_secret = get_client_secret(f"/{env}/keycloak/backend_checks_client/secret")
+
+print(f"::set-output name=user_admin_secret::{user_admin_secret}")
+print(f"::set-output name=backend_checks_secret::{backend_checks_secret}")
+print(f"::add-mask::{backend_checks_secret}")
+print(f"::add-mask::{user_admin_secret}")

--- a/.github/scripts/set_secret_names.py
+++ b/.github/scripts/set_secret_names.py
@@ -3,7 +3,5 @@ is_pr = len(sys.argv) == 1
 env = "intg" if is_pr else sys.argv[1]
 print(f"::set-output name=environment::{env}")
 print(f"::set-output name=account_number_secret::{env.upper()}_ACCOUNT_NUMBER")
-print(f"::set-output name=user_admin_secret::{env.upper()}_USER_ADMIN_SECRET")
-print(f"::set-output name=backend_checks_secret::{env.upper()}_BACKEND_CHECKS_SECRET")
 print(f"::set-output name=title_environment::{env.title()}")
 print(f"::set-output name=is_pr::{is_pr}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGitHubActionsGetE2ESecretsRole${{ needs.setup-e2e-tests.outputs.title_environment }}
+          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ needs.setup-e2e-tests.outputs.title_environment }}
           aws-region: eu-west-2
           role-session-name: GetKeycloakSecrets
       - id: get-keycloak-secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       files: ${{ steps.generate-files.outputs.files }}
       environment: ${{ steps.set-secret-names.outputs.environment }}
       account_number_secret: ${{ steps.set-secret-names.outputs.account_number_secret }}
-      user_admin_secret: ${{ steps.set-secret-names.outputs.user_admin_secret }}
-      backend_checks_secret: ${{ steps.set-secret-names.outputs.backend_checks_secret }}
+      user_admin_secret: ${{ steps.get-keycloak-secrets.outputs.user_admin_secret }}
+      backend_checks_secret: ${{ steps.get-keycloak-secrets.outputs.backend_checks_secret }}
       title_environment: ${{ steps.set-secret-names.outputs.title_environment }}
       is_pr: ${{ steps.set-secret-names.outputs.is_pr }}
       last_status: ${{ steps.get-last-status.outputs.last_status }}
@@ -44,6 +44,14 @@ jobs:
         run: pip install requests && python .github/scripts/get_last_status.py
       - id: set-secret-names
         run: python .github/scripts/set_secret_names.py ${{ github.event.inputs.environment }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGitHubActionsGetE2ESecretsRole${{ needs.setup-e2e-tests.outputs.title_environment }}
+          aws-region: eu-west-2
+          role-session-name: GetKeycloakSecrets
+      - id: get-keycloak-secrets
+        run: pip install boto3 && python .github/scripts/get_keycloak_secrets.py ${{ github.event.inputs.environment }}
       - name: Set feature file names
         id: generate-files
         run: |
@@ -76,7 +84,7 @@ jobs:
       - name: Run Tests
         env:
           DRIVER_LOCATION: ${{ needs.setup-e2e-tests.outputs.driver }}
-        run: sbt test -Daccount.number=${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }} -Dconfig.file=./src/test/resources/application.${{ needs.setup-e2e-tests.outputs.environment }}.conf -Dkeycloak.user.admin.secret=${{ secrets[needs.setup-e2e-tests.outputs.user_admin_secret] }} -Dkeycloak.backendchecks.secret=${{ secrets[needs.setup-e2e-tests.outputs.backend_checks_secret] }} -Dbrowser=${{ needs.setup-e2e-tests.outputs.browser }} -Dcucumber.features=./src/test/resources/features/${{ matrix.file }}
+        run: sbt test -Daccount.number=${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }} -Dconfig.file=./src/test/resources/application.${{ needs.setup-e2e-tests.outputs.environment }}.conf -Dkeycloak.user.admin.secret=${{ needs.setup-e2e-tests.outputs.user_admin_secret }} -Dkeycloak.backendchecks.secret=${{ needs.setup-e2e-tests.outputs.backend_checks_secret }} -Dbrowser=${{ needs.setup-e2e-tests.outputs.browser }} -Dcucumber.features=./src/test/resources/features/${{ matrix.file }}
       - name: Configure AWS credentials
         if: ${{ always() }}
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
       files: ${{ steps.generate-files.outputs.files }}
       environment: ${{ steps.set-secret-names.outputs.environment }}
       account_number_secret: ${{ steps.set-secret-names.outputs.account_number_secret }}
-      user_admin_secret: ${{ steps.get-keycloak-secrets.outputs.user_admin_secret }}
-      backend_checks_secret: ${{ steps.get-keycloak-secrets.outputs.backend_checks_secret }}
       title_environment: ${{ steps.set-secret-names.outputs.title_environment }}
       is_pr: ${{ steps.set-secret-names.outputs.is_pr }}
       last_status: ${{ steps.get-last-status.outputs.last_status }}
@@ -44,14 +42,6 @@ jobs:
         run: pip install requests && python .github/scripts/get_last_status.py
       - id: set-secret-names
         run: python .github/scripts/set_secret_names.py ${{ github.event.inputs.environment }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets[steps.set-secret-names.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ steps.set-secret-names.outputs.title_environment }}
-          aws-region: eu-west-2
-          role-session-name: GetKeycloakSecrets
-      - id: get-keycloak-secrets
-        run: pip install boto3 && python .github/scripts/get_keycloak_secrets.py ${{ github.event.inputs.environment }}
       - name: Set feature file names
         id: generate-files
         run: |
@@ -70,6 +60,14 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
+          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ needs.setup-e2e-tests.outputs.title_environment }}
+          aws-region: eu-west-2
+          role-session-name: GetKeycloakSecrets
+      - id: get-keycloak-secrets
+        run: pip install boto3 && python .github/scripts/get_keycloak_secrets.py ${{ github.event.inputs.environment }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
           role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRUpdateWAFAndSecurityGroupsRole${{ needs.setup-e2e-tests.outputs.title_environment }}
           aws-region: eu-west-2
           role-session-name: UpdateWAF
@@ -84,7 +82,7 @@ jobs:
       - name: Run Tests
         env:
           DRIVER_LOCATION: ${{ needs.setup-e2e-tests.outputs.driver }}
-        run: sbt test -Daccount.number=${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }} -Dconfig.file=./src/test/resources/application.${{ needs.setup-e2e-tests.outputs.environment }}.conf -Dkeycloak.user.admin.secret=${{ needs.setup-e2e-tests.outputs.user_admin_secret }} -Dkeycloak.backendchecks.secret=${{ needs.setup-e2e-tests.outputs.backend_checks_secret }} -Dbrowser=${{ needs.setup-e2e-tests.outputs.browser }} -Dcucumber.features=./src/test/resources/features/${{ matrix.file }}
+        run: sbt test -Daccount.number=${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }} -Dconfig.file=./src/test/resources/application.${{ needs.setup-e2e-tests.outputs.environment }}.conf -Dkeycloak.user.admin.secret=${{ steps.get-keycloak-secrets.outputs.user_admin_secret }} -Dkeycloak.backendchecks.secret=${{ steps.get-keycloak-secrets.outputs.backend_checks_secret }} -Dbrowser=${{ needs.setup-e2e-tests.outputs.browser }} -Dcucumber.features=./src/test/resources/features/${{ matrix.file }}
       - name: Configure AWS credentials
         if: ${{ always() }}
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ needs.setup-e2e-tests.outputs.title_environment }}
+          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ steps.set-secret-names.outputs.title_environment }}
           aws-region: eu-west-2
           role-session-name: GetKeycloakSecrets
       - id: get-keycloak-secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ steps.set-secret-names.outputs.title_environment }}
+          role-to-assume: arn:aws:iam::${{ secrets[steps.set-secret-names.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ steps.set-secret-names.outputs.title_environment }}
           aws-region: eu-west-2
           role-session-name: GetKeycloakSecrets
       - id: get-keycloak-secrets


### PR DESCRIPTION
 Get secrets from ssm.
    
The secrets are coming from the repository secrets which are set by terraform. This is then failing every time the secrets are rotated. This should get them from systems manager and pass them to the sbt command.

This https://github.com/nationalarchives/tdr-terraform-environments/pull/261 will need to be deployed to integration and staging before this will work properly.