### PR TITLE
Add tests for downloading metadata.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   lazy val scalaTestPlusPlay   = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0"
   lazy val keycloakCore        = "org.keycloak" % "keycloak-core" % keycloakVersion
   lazy val keycloakAdminClient = "org.keycloak" % "keycloak-admin-client" % keycloakVersion
-  lazy val tdrGenerateGraphQl  = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.264"
+  lazy val tdrGenerateGraphQl  = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.265-SNAPSHOT"
   lazy val circeCore           = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric        = "io.circe" %% "circe-generic" % circeVersion
   lazy val softwareMillCore    = "com.softwaremill.sttp.client" %% "core" % softwareMillVersion

--- a/src/test/resources/features/DownloadMetadata.feature
+++ b/src/test/resources/features/DownloadMetadata.feature
@@ -1,0 +1,36 @@
+Feature: Download Metadata page
+
+  Scenario: Download metadata page contains an image, a link and a continue button
+    Given A logged out standard user
+    And an existing standard consignment for transferring body MOCK1
+    And the user is logged in on the Download Metadata page
+    Then the download metadata page elements are loaded
+
+  Scenario: Download metadata page is accessed by a logged out user
+    Given A logged out standard user
+    And an existing standard consignment for transferring body MOCK1
+    And the logged out user attempts to access the Download Metadata page
+    Then the logged out user should be on the login page
+
+  Scenario: Download metadata page is accessed by a user who did not create the consignment
+    Given A logged out standard user
+    And an existing standard consignment for transferring body MOCK1
+    And a user who did not create the consignment
+    When the user who did not create the consignment is logged in on the Download Metadata page
+    Then the user who did not create the consignment will see the error message "You are not permitted to see this page"
+
+  Scenario: Download metadata page is accessed by a judgment user
+    Given A logged out judgment user
+    And an existing judgment consignment for transferring body MOCK1
+    And a user who did not create the consignment
+    When the logged in user navigates to the Download Metadata page
+    Then the user should see a general service error "Page not found"
+
+  Scenario: Metadata CSV is downloaded by a logged in user
+    Given A logged out standard user
+    And an existing standard consignment for transferring body MOCK1
+    And the user is logged in on the Download Metadata page
+    And the file checks are complete
+    And the user has created additional metadata
+    And the user clicks the download metadata link
+    Then the metadata csv will have the correct columns for 2 files

--- a/src/test/resources/features/DownloadMetadata.feature
+++ b/src/test/resources/features/DownloadMetadata.feature
@@ -20,9 +20,8 @@ Feature: Download Metadata page
     Then the user who did not create the consignment will see the error message "You are not permitted to see this page"
 
   Scenario: Download metadata page is accessed by a judgment user
-    Given A logged out judgment user
+    Given A logged in judgment user
     And an existing judgment consignment for transferring body MOCK1
-    And a user who did not create the consignment
     When the logged in user navigates to the Download Metadata page
     Then the user should see a general service error "Page not found"
 

--- a/src/test/scala/helpers/drivers/DriverUtility.scala
+++ b/src/test/scala/helpers/drivers/DriverUtility.scala
@@ -19,6 +19,7 @@ object DriverUtility {
     chromeOptions.addArguments("--no-sandbox")
     chromeOptions.addArguments("--disable-dev-shm-usage")
     chromeOptions.addArguments("--verbose")
+    chromeOptions.setExperimentalOption("download.default_directory", "/tmp")
     System.setProperty("webdriver.chrome.driver", driverLocation)
 
     chromeOptions
@@ -26,11 +27,15 @@ object DriverUtility {
 
   val firefoxOptions: FirefoxOptions = {
     val firefoxOptions = new FirefoxOptions
+    firefoxOptions.addPreference("browser.download.dir", "/tmp")
+    firefoxOptions.addPreference("browser.download.useDownloadDir", true)
+    firefoxOptions.addPreference("browser.download.folderList", 2)
     firefoxOptions.setHeadless(true)
     firefoxOptions.setBinary(firefoxBinaryLocation)
     firefoxOptions.addArguments("--no-sandbox")
     firefoxOptions.addArguments("--disable-dev-shm-usage")
     firefoxOptions.addArguments("--verbose")
+
     System.setProperty("webdriver.gecko.driver", driverLocation)
 
     firefoxOptions

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -83,7 +83,7 @@ class GraphqlUtility(userCredentials: UserCredentials) {
     client.result(gcs.document, gcs.Variables(consignmentId)).data.get.getConsignment.get.consignmentReference
   }
 
-  def createMetadata(consignmentId: UUID): Unit = {
+  def createCustomMetadata(consignmentId: UUID): Unit = {
     val client = new UserApiClient[abfm.Data, abfm.Variables](userCredentials)
     val metadataProperties = getCustomMetadata(consignmentId).filter(_.allowExport)
     val files = getConsignmentExport(consignmentId).get.getConsignment.get.files.filter(!_.fileType.contains("Folder"))

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -7,11 +7,14 @@ import graphql.codegen.AddFilesAndMetadata.{addFilesAndMetadata => afam}
 import graphql.codegen.StartUpload.{startUpload => su}
 import graphql.codegen.AddConsignment.{addConsignment => ac}
 import graphql.codegen.AddFileMetadata.{addFileMetadata => afm}
+import graphql.codegen.AddBulkFileMetadata.{addBulkFileMetadata => abfm}
 import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => affm}
 import graphql.codegen.AddTransferAgreementPrivateBeta.{addTransferAgreementPrivateBeta => atapb}
 import graphql.codegen.AddTransferAgreementCompliance.{addTransferAgreementCompliance => atac}
+import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
 import graphql.codegen.GetSeries.{getSeries => gs}
 import graphql.codegen.GetConsignmentExport.{getConsignmentForExport => gcfe}
+import graphql.codegen.GetConsignmentSummary.{getConsignmentSummary => gcs}
 import graphql.codegen.UpdateConsignmentSeriesId.{updateConsignmentSeriesId => ucs}
 import graphql.codegen.types._
 import helpers.graphql.GraphqlUtility.MatchIdInfo
@@ -73,6 +76,35 @@ class GraphqlUtility(userCredentials: UserCredentials) {
     )
     val input = AddFileAndMetadataInput(consignmentId, metadataInput, None)
     client.result(afam.document, afam.Variables(input)).data.get.addFilesAndMetadata
+  }
+
+  def getConsignmentReference(consignmentId: UUID): String = {
+    val client = new UserApiClient[gcs.Data, gcs.Variables](userCredentials)
+    client.result(gcs.document, gcs.Variables(consignmentId)).data.get.getConsignment.get.consignmentReference
+  }
+
+  def createMetadata(consignmentId: UUID): Unit = {
+    val client = new UserApiClient[abfm.Data, abfm.Variables](userCredentials)
+    val metadataProperties = getCustomMetadata(consignmentId).filter(_.allowExport)
+    val files = getConsignmentExport(consignmentId).get.getConsignment.get.files.filter(!_.fileType.contains("Folder"))
+    val fileIds =  files.map(_.fileId)
+    val updateMetadata = metadataProperties.map(prop => {
+      val value = prop.dataType match {
+        case DataType.DateTime => "2022-09-28 14:31:17.746"
+        case DataType.Text => s"${prop.name}-value"
+        case DataType.Boolean => "true"
+        case _ => "1"
+      }
+      UpdateFileMetadataInput(prop.name, value)
+    })
+    val input = UpdateBulkFileMetadataInput(consignmentId, fileIds, updateMetadata)
+    client.result(abfm.document, abfm.Variables(input))
+  }
+
+  def getCustomMetadata(consignmentId: UUID): List[cm.CustomMetadata] = {
+    val client = new BackendApiClient[cm.Data, cm.Variables]()
+    val variables = cm.Variables(consignmentId)
+    client.sendRequest(cm.document, variables).data.get.customMetadata
   }
 
   def createAVMetadata(fileId: UUID, result: String = ""): Unit = {

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -503,15 +503,15 @@ class Steps extends ScalaDsl with EN with Matchers {
       val consignmentRef = client.getConsignmentReference(consignmentId)
       val source = Source.fromFile(s"/tmp/$consignmentRef-metadata.csv")
       val rows = source.getLines().toList
-      def filterCsvRows(num: Int): Option[String] = rows.find(_ == s"E2E_tests/original/path$num,true,2022-09-28 14:31:17.746,true,1")
+      def filterCsvRows(num: Int): Option[String] = rows.find(_ == s"path$num,FileType-value,1,E2E_tests/original/path$num,RightsCopyright-value,LegalStatus-value,HeldBy-value,2022-09-28 14:31:17.746,ClosureType-value,2022-09-28 14:31:17.746,1,FoiExemptionCode-value,2022-09-28 14:31:17.746,true,TitleAlternate-value,description-value,true,DescriptionAlternate-value,Language-value,2022-09-28 14:31:17.746,date_range-value,2022-09-28 14:31:17.746,2022-09-28 14:31:17.746,file_name_language-value,file_name_translation-value,file_name_translation_language-value")
 
       Assert.assertEquals(rows.size, numberOfFiles + 1)
       val customMetadata = client.getCustomMetadata(consignmentId).filter(_.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
       val headerRow = rows.head.split(",")
-      Assert.assertEquals(headerRow.length, customMetadata.size + 1)
+      Assert.assertEquals(headerRow.length, customMetadata.size)
       Assert.assertTrue(filterCsvRows(0).isDefined)
       Assert.assertTrue(filterCsvRows(1).isDefined)
-      headerRow.tail.zipWithIndex.map {
+      headerRow.zipWithIndex.map {
         case (title, idx) =>
           val customMetadataName = customMetadata(idx).fullName.getOrElse("")
           Assert.assertEquals(customMetadataName, title)

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -494,7 +494,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   And("^the user has created additional metadata") {
     val client = GraphqlUtility(userCredentials)
-    client.createMetadata(consignmentId)
+    client.createCustomMetadata(consignmentId)
   }
 
   Then("^the metadata csv will have the correct columns for (.*) files") {


### PR DESCRIPTION
There are the usual tests checking for page elements and checking access for different user types.

There is also a test that downloads the CSV and checks it for the expected content.

This needs https://github.com/nationalarchives/tdr-generated-graphql/pull/672 before it can be merged.