### PR TITLE
Remove trailing slash from url

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -77,7 +77,7 @@ class Steps extends ScalaDsl with EN with Matchers {
     val pageWithConsignment = page match {
       case "homepage" | "some-page" => s"$baseUrl/$page"
       case "faq" | "help" => if(isJudgment) s"$baseUrl/$path/$page" else s"$baseUrl/$page"
-      case "Download Metadata" => s"$baseUrl/$path/$consignmentId/additional-metadata/${page.toLowerCase.replaceAll(" ", "-")}/"
+      case "Download Metadata" => s"$baseUrl/$path/$consignmentId/additional-metadata/${page.toLowerCase.replaceAll(" ", "-")}"
       case _ => s"$baseUrl/$path/$consignmentId/${page.toLowerCase.replaceAll(" ", "-")}"
     }
     webDriver.get(pageWithConsignment)


### PR DESCRIPTION
The urls in the front end have been tidied up so none of them now end in
a slash. This needs to be updated to match.
