### PR TITLE
Remove allEnglish and openRecords.

### DIFF
--- a/src/test/resources/features/TransferAgreementPrivateBeta.feature
+++ b/src/test/resources/features/TransferAgreementPrivateBeta.feature
@@ -14,10 +14,10 @@ Feature: Transfer Agreement Page
     And an existing standard consignment for transferring body MOCK1
     And an selected series MOCK1
     And the user is logged in on the Transfer Agreement page
-    When the user selects yes for all checks except "The records are all English"
+    When the user selects yes for all checks except "I confirm that the records are all Crown Copyright."
     And the user clicks the continue button
-    Then the user will see a form error message "All records must be confirmed as English language before proceeding"
-    Then the user will see a summary error message "All records must be confirmed as English language before proceeding"
+    Then the user will see a form error message "All records must be confirmed Crown Copyright before proceeding"
+    Then the user will see a summary error message "All records must be confirmed Crown Copyright before proceeding"
 
   Scenario: Consignment transfer agreement page is accessed by a logged out user
     Given A logged out standard user

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -369,43 +369,35 @@ class Steps extends ScalaDsl with EN with Matchers {
       })
   }
 
-  When("^the user selects yes for all checks except \"The records are all English\"") {
+  When("^the user selects yes for all checks except \"I confirm that the records are all Crown Copyright.\"") {
     new WebDriverWait(webDriver, 30).until((driver: WebDriver) => {
-      val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecord"))
-      val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyright"))
+      webDriver.findElement(By.id("publicRecord"))
+      webDriver.findElement(By.id("crownCopyright"))
     })
     val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecord"))
-    val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyright"))
     recordsAllPublicRecords.click()
-    recordsAllCrownCopyright.click()
   }
 
   When("^the user selects yes to all transfer agreement checks") {
     new WebDriverWait(webDriver, 30).until((driver: WebDriver) => {
       webDriver.findElement(By.id("publicRecord"))
       webDriver.findElement(By.id("crownCopyright"))
-      webDriver.findElement(By.id("english"))
     })
     val recordsAllPublicRecords = webDriver.findElement(By.id("publicRecord"))
     val recordsAllCrownCopyright = webDriver.findElement(By.id("crownCopyright"))
-    val recordsAllEnglish = webDriver.findElement(By.id("english"))
     recordsAllPublicRecords.click()
     recordsAllCrownCopyright.click()
-    recordsAllEnglish.click()
   }
 
   When("^the user selects yes to all transfer agreement continued checks") {
     val recordsDroAppraisal = webDriver.findElement(By.id("droAppraisalSelection"))
     val recordsDroSensitivity = webDriver.findElement(By.id("droSensitivity"))
-    val recordsOpenRecords = webDriver.findElement(By.id("openRecords"))
     new WebDriverWait(webDriver, 30).until((driver: WebDriver) => {
       recordsDroAppraisal
       recordsDroSensitivity
-      recordsOpenRecords
     })
     recordsDroAppraisal.click()
     recordsDroSensitivity.click()
-    recordsOpenRecords.click()
   }
 
   And("^the user confirms that DRO has signed off on the records") {


### PR DESCRIPTION
These checkboxes are not part of integration and staging any more. I've
removed them from the full list of transfer agreement fields and updated
the tests that checks to see what happens if you don't click it.
