### PR TITLE
FileChecksResults fix

### DIFF
--- a/src/test/resources/features/FileChecksResults.feature
+++ b/src/test/resources/features/FileChecksResults.feature
@@ -1,5 +1,4 @@
 Feature: File Checks results Page
-
   Scenario: The user will see a success message when they access the file checks results page once file checks are complete
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
@@ -9,7 +8,7 @@ Feature: File Checks results Page
     And the user is logged in on the file checks results page
     And the user will be on a page with the title "Results of your checks"
     And the user should see a banner titled Success
-    When the user clicks on the Continue button
+    When the user clicks on the Next button
     Then the user will be on a page with the title "Descriptive & closure metadata"
 
   Scenario: The user will see an error when trying to access file check results for a consignment they don't own

--- a/src/test/resources/features/StandardFullflow.feature
+++ b/src/test/resources/features/StandardFullflow.feature
@@ -31,7 +31,7 @@ Feature: Standard Full user journey
     When the user clicks the continue button
     Then the user will be on a page with the title "Results of your checks"
     And the user should see a banner titled Success
-    When the user clicks on the Continue button
+    When the user clicks on the Next button
     Then the user will be on a page with the title "Descriptive & closure metadata"
     # currently skip adding additional metadata
     When the user clicks on the Next button

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -295,7 +295,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   And("^the user should see a banner titled Success") {
     () =>
-      StepsUtility.waitForElementTitle(webDriver, "Success", "success-summary__title")
+      StepsUtility.waitForElementTitle(webDriver, "Success", "govuk-notification-banner__title")
   }
 
   Then("^the user should see a general service error \"(.*)\"") {


### PR DESCRIPTION
This should fix the e2e tests once the content changes for the [file checks results success content changes](https://github.com/nationalarchives/tdr-transfer-frontend/pull/2673) is merged.