### PR TITLE
Updates for the download metadata pages

### DIFF
--- a/src/test/resources/features/StandardFullflow.feature
+++ b/src/test/resources/features/StandardFullflow.feature
@@ -36,7 +36,7 @@ Feature: Standard Full user journey
     # currently skip adding additional metadata
     When the user clicks on the Next button
     Then the user will be on a page with the title "Download or view metadata"
-    When the user clicks on the Continue button
+    When the user clicks on the Next button
     Then the user will be on a page with the title "Confirm transfer"
     When the user confirms that they are transferring legal custody of the records to TNA
     And the user clicks the Transfer your records button

--- a/src/test/resources/features/StandardFullflow.feature
+++ b/src/test/resources/features/StandardFullflow.feature
@@ -35,7 +35,7 @@ Feature: Standard Full user journey
     Then the user will be on a page with the title "Descriptive & closure metadata"
     # currently skip adding additional metadata
     When the user clicks on the Next button
-    Then the user will be on a page with the title "Download or view metadata"
+    Then the user will be on a page with the title "Download and review metadata"
     When the user clicks on the Next button
     Then the user will be on a page with the title "Confirm transfer"
     When the user confirms that they are transferring legal custody of the records to TNA

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -801,11 +801,11 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   Then("^the download metadata page elements are loaded") {
     val href = webDriver.findElement(By.cssSelector("a.download-metadata")).getAttribute("href")
-    val buttonText = webDriver.findElement(By.cssSelector("a.govuk-button")).getText
-    val svgClass = webDriver.findElement(By.cssSelector("svg")).getAttribute("class")
+    val buttonText = webDriver.findElements(By.cssSelector("a.govuk-button")).asScala.last.getText
+    val svg = webDriver.findElement(By.cssSelector("svg"))
 
     Assert.assertEquals(s"$baseUrl/consignment/$consignmentId/additional-metadata/download-metadata/csv", href)
-    Assert.assertEquals("Continue", buttonText)
-    Assert.assertEquals("thumbnail-icon", svgClass)
+    Assert.assertEquals("Next", buttonText)
+    Assert.assertNotNull(svg)
   }
 }


### PR DESCRIPTION
The Continue button is now Next, the svg icon no longer has a class and
there are two .govuk-button links so we need to select the right one.

The tests won't pass until https://github.com/nationalarchives/tdr-transfer-frontend/pull/2681 but this is ready for review now.