### PR TITLE
Update tests to check download columns based on DisplayProperties.

### DIFF
--- a/src/test/resources/features/DescriptiveMetadata.feature
+++ b/src/test/resources/features/DescriptiveMetadata.feature
@@ -47,6 +47,8 @@ Feature: Descriptive metadata pages
     Then the user will be on the "Descriptive metadata" "Add or edit metadata" page
     When the user enters some description for the description field
     And the user enters 07/03/2023 for the date of the record field
+    And the user enters translated title for the translated title field
+    And the user enters some reference for the former reference field
     When the user clicks the Save and Review button
     Then the user will be on a page with the title "Review saved changes"
 

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -19,7 +19,9 @@ import graphql.codegen.GetDisplayProperties.{displayProperties => dp}
 import graphql.codegen.GetSeries.{getSeries => gs}
 import graphql.codegen.GetConsignmentExport.{getConsignmentForExport => gcfe}
 import graphql.codegen.GetConsignmentSummary.{getConsignmentSummary => gcs}
+import graphql.codegen.StartUpload.{startUpload => su}
 import graphql.codegen.UpdateConsignmentSeriesId.{updateConsignmentSeriesId => ucs}
+import graphql.codegen.UpdateConsignmentStatus.{updateConsignmentStatus => ucst}
 import graphql.codegen.types._
 import helpers.graphql.GraphqlUtility.MatchIdInfo
 import helpers.keycloak.UserCredentials
@@ -38,6 +40,11 @@ class GraphqlUtility(userCredentials: UserCredentials) {
       val seriesId: UUID = getSeries(body).get.getSeries.head.seriesid
       client.result(ac.document, ac.Variables(AddConsignmentInput(Some(seriesId), standardConsignmentType))).data
     }
+  }
+
+  def startUpload(consignmentId: UUID, parentFolder: String = "parent"): Option[su.Data] = {
+    val client = new UserApiClient[su.Data, su.Variables](userCredentials)
+    client.result(su.document, su.Variables(StartUploadInput(consignmentId, parentFolder, None))).data
   }
 
   def getSeries(body: String): Option[gs.Data] = {
@@ -86,6 +93,11 @@ class GraphqlUtility(userCredentials: UserCredentials) {
     val fileStatusClient = new UserApiClient[afs.Data, afs.Variables](userCredentials)
     val variables = afs.Variables(AddFileStatusInput(fileId, statusType, statusValue))
     fileStatusClient.result(afs.document, variables).data.get.addFileStatus
+  }
+
+  def updateConsignmentStatus(consignmentId: UUID, statusType: String, statusValue: String): Option[ucst.Data] = {
+    val addConsignmentStatusClient = new UserApiClient[ucst.Data, ucst.Variables](userCredentials)
+    addConsignmentStatusClient.result(ucst.document, ucst.Variables(ConsignmentStatusInput(consignmentId, statusType, Option(statusValue)))).data
   }
 
   def getConsignmentReference(consignmentId: UUID): String = {

--- a/src/test/scala/helpers/graphql/GraphqlUtility.scala
+++ b/src/test/scala/helpers/graphql/GraphqlUtility.scala
@@ -15,6 +15,7 @@ import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => affm}
 import graphql.codegen.AddTransferAgreementPrivateBeta.{addTransferAgreementPrivateBeta => atapb}
 import graphql.codegen.AddTransferAgreementCompliance.{addTransferAgreementCompliance => atac}
 import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
+import graphql.codegen.GetDisplayProperties.{displayProperties => dp}
 import graphql.codegen.GetSeries.{getSeries => gs}
 import graphql.codegen.GetConsignmentExport.{getConsignmentForExport => gcfe}
 import graphql.codegen.GetConsignmentSummary.{getConsignmentSummary => gcs}
@@ -164,6 +165,11 @@ class GraphqlUtility(userCredentials: UserCredentials) {
     }
     val updateBulkFileMetadataInput = UpdateBulkFileMetadataInput(consignmentId, fileIds, metadataInput)
     client.result(abfm.document, abfm.Variables(updateBulkFileMetadataInput)).data
+  }
+
+  def getDisplayProperties(consignmentId: UUID): Option[dp.Data] = {
+    val client = new UserApiClient[dp.Data, dp.Variables](userCredentials)
+    client.result(dp.document, dp.Variables(consignmentId)).data
   }
 }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -920,6 +920,9 @@ class Steps extends ScalaDsl with EN with Matchers {
       webDriver.findElement(By.cssSelector(s"#$input-month")).sendKeys(month)
       webDriver.findElement(By.cssSelector(s"#$input-year")).sendKeys(year)
     case "closure period" => webDriver.findElement(By.id("Years")).sendKeys(value)
+    case "translated title" =>
+      webDriver.findElement(By.name("inputtext-file_name_translation-")).sendKeys(value)
+    case "former reference" => webDriver.findElement(By.name("inputtext-former_reference_department-")).sendKeys(value)
   }
 
   And("^the user confirms the closure status of the selected file") {

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -533,6 +533,8 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   And("^the file checks are complete") {
     val client = GraphqlUtility(userCredentials)
+    client.startUpload(consignmentId)
+    client.updateConsignmentStatus(consignmentId, "Upload", "Completed")
     val files = List("testfile1", "testfile2")
     val checksumWithIndex: List[MatchIdInfo] = files.zipWithIndex.map({
       case (fileName, idx) =>
@@ -550,7 +552,6 @@ class Steps extends ScalaDsl with EN with Matchers {
       client.createFfidMetadata(fm.fileId)
       client.addFileStatus(fm.fileId, "FFID", "Success")
     })
-
   }
 
   And("^the (checksum|antivirus|FFID) check has (.*)") {


### PR DESCRIPTION
The front end has been updated. I've changed the tests to match.

I've also fixed the file checks results checks by setting the consignment status for Upload and adding the parent folder.

There was also an error with the descriptive metadata because the translated title and former reference fields are mandatory. I know they're not supposed to be but it won't hurt to fill them in on the tests. At the moment, the ids are empty and the names end in a dash so this will need to be fixed properly later. 