### PR TITLE
Confirm closure status before adding closure metadata

### DIFF
--- a/src/test/resources/features/ClosureMetadata.feature
+++ b/src/test/resources/features/ClosureMetadata.feature
@@ -36,6 +36,10 @@ Feature: Closure Metadata Pages
     Given A logged in standard user
     And an existing standard consignment for transferring body MOCK1
     And an existing upload of 2 files
+    And the logged in user navigates to the confirm closure status page for closure metadata
+    Then the user will be on the "Closure metadata" "Confirm closure status" page
+    When the user confirms the closure status of the selected file
+    And the user clicks the Continue button
     And the logged in user navigates to the add metadata page for closure metadata
     Then the user will be on the "Closure metadata" "Add or edit closure metadata" page
     When the user enters 01/01/2023 for the FOI decision asserted field
@@ -46,7 +50,10 @@ Feature: Closure Metadata Pages
     Given A logged in standard user
     And an existing standard consignment for transferring body MOCK1
     And an existing upload of 2 files
-    And the logged in user navigates to the add metadata page for closure metadata
+    And the logged in user navigates to the confirm closure status page for closure metadata
+    Then the user will be on the "Closure metadata" "Confirm closure status" page
+    When the user confirms the closure status of the selected file
+    And the user clicks the Continue button
     Then the user will be on the "Closure metadata" "Add or edit closure metadata" page
     When the user enters 01/01/2023 for the FOI decision asserted field
     And the user enters 07/03/2023 for the closure start date field

--- a/src/test/resources/features/DescriptiveMetadata.feature
+++ b/src/test/resources/features/DescriptiveMetadata.feature
@@ -37,7 +37,7 @@ Feature: Descriptive metadata pages
     Then the user will be on the "Descriptive metadata" "Add or edit descriptive metadata" page
     And the user de-selects "English" for the Language field
     When the user clicks the Save and Review button
-    Then the user will see a form error message "Search for and select at least one Language"
+    Then the user will see a form error message "Select at least one Language"
 
   Scenario: Standard user completes all fields on descriptive metadata form
     Given A logged in standard user


### PR DESCRIPTION
Confirm closure status before adding closure metadata as it doesn't allow to add closure metadata if closure status is open