### PR TITLE
Fix confirm transfer e2e tests

### DIFF
--- a/src/test/resources/features/ConfirmTransfer.feature
+++ b/src/test/resources/features/ConfirmTransfer.feature
@@ -57,11 +57,11 @@ Feature: Confirm Transfer Page
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
-    And an existing upload of 2 files
-    And the file checks are complete
-#    And 3 of the antivirus scans for the standard transfer have finished
-#    And 3 of the FFID scans for the standard transfer have finished
-#    And 3 of the checksum scans for the standard transfer have finished
+    And an existing upload of 3 files
+#    And the file checks are complete
+    And 3 of the antivirus scans for the standard transfer have finished
+    And 3 of the FFID scans for the standard transfer have finished
+    And 3 of the checksum scans for the standard transfer have finished
     And the user is logged in on the Confirm Transfer page
     Then the user will be on a page with the title "Confirm transfer"
     When the user confirms that they are transferring legal custody of the records to TNA

--- a/src/test/resources/features/ConfirmTransfer.feature
+++ b/src/test/resources/features/ConfirmTransfer.feature
@@ -23,11 +23,11 @@ Feature: Confirm Transfer Page
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
-    And an existing upload of 3 files
-#    And the file checks are complete
+#    And an existing upload of 3 files
+    And the file checks are complete
     And the user is logged in on the Confirm Transfer page
     When the user will be on a page with the title "Confirm transfer"
-    Then the confirm transfer page shows the user that 3 files have been uploaded
+    Then the confirm transfer page shows the user that 2 files have been uploaded
 
   Scenario: Confirm transfer will show all summary information
     Given A logged out standard user
@@ -35,11 +35,11 @@ Feature: Confirm Transfer Page
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
-    And an existing upload of 4 files
-#    And the file checks are complete
+    And the file checks are complete
+#    And an existing upload of 4 files
     And the user is logged in on the Confirm Transfer page
     When the user will be on a page with the title "Confirm transfer"
-    Then the confirm transfer page shows the user that 4 files have been uploaded
+    Then the confirm transfer page shows the user that 2 files have been uploaded
     And the user sees a transfer confirmation with related information
 
   Scenario: A logged in user submits Final Transfer Confirmation form without confirming anything
@@ -48,8 +48,7 @@ Feature: Confirm Transfer Page
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
-    And an existing upload of 3 files
-#    And the file checks are complete
+    And the file checks are complete
     And the user is logged in on the Confirm Transfer page
     When the user clicks the continue button
     Then the user will see all of the Final Transfer Confirmation form's error messages
@@ -57,14 +56,14 @@ Feature: Confirm Transfer Page
   Scenario: Submitting the Final Transfer Confirmation form creates a completed export
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
+#    And an existing upload of 3 files
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
-    And an existing upload of 3 files
-#    And the file checks are complete
-    And 3 of the antivirus scans for the standard transfer have finished
-    And 3 of the FFID scans for the standard transfer have finished
-    And 3 of the checksum scans for the standard transfer have finished
+    And the file checks are complete
+#    And 3 of the antivirus scans for the standard transfer have finished
+#    And 3 of the FFID scans for the standard transfer have finished
+#    And 3 of the checksum scans for the standard transfer have finished
     And the user is logged in on the Confirm Transfer page
     Then the user will be on a page with the title "Confirm transfer"
     When the user confirms that they are transferring legal custody of the records to TNA

--- a/src/test/resources/features/ConfirmTransfer.feature
+++ b/src/test/resources/features/ConfirmTransfer.feature
@@ -58,7 +58,6 @@ Feature: Confirm Transfer Page
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
     And an existing upload of 3 files
-#    And the file checks are complete
     And 3 of the antivirus scans for the standard transfer have finished
     And 3 of the FFID scans for the standard transfer have finished
     And 3 of the checksum scans for the standard transfer have finished

--- a/src/test/resources/features/ConfirmTransfer.feature
+++ b/src/test/resources/features/ConfirmTransfer.feature
@@ -20,7 +20,11 @@ Feature: Confirm Transfer Page
   Scenario: Consignment confirm transfer page shows the same number of files as were uploaded
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
+    And an existing selected series MOCK1
+    And an existing transfer agreement part 1
+    And an existing transfer agreement part 2
     And an existing upload of 3 files
+#    And the file checks are complete
     And the user is logged in on the Confirm Transfer page
     When the user will be on a page with the title "Confirm transfer"
     Then the confirm transfer page shows the user that 3 files have been uploaded
@@ -28,7 +32,11 @@ Feature: Confirm Transfer Page
   Scenario: Confirm transfer will show all summary information
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
+    And an existing selected series MOCK1
+    And an existing transfer agreement part 1
+    And an existing transfer agreement part 2
     And an existing upload of 4 files
+#    And the file checks are complete
     And the user is logged in on the Confirm Transfer page
     When the user will be on a page with the title "Confirm transfer"
     Then the confirm transfer page shows the user that 4 files have been uploaded
@@ -37,6 +45,11 @@ Feature: Confirm Transfer Page
   Scenario: A logged in user submits Final Transfer Confirmation form without confirming anything
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
+    And an existing selected series MOCK1
+    And an existing transfer agreement part 1
+    And an existing transfer agreement part 2
+    And an existing upload of 3 files
+#    And the file checks are complete
     And the user is logged in on the Confirm Transfer page
     When the user clicks the continue button
     Then the user will see all of the Final Transfer Confirmation form's error messages
@@ -44,7 +57,11 @@ Feature: Confirm Transfer Page
   Scenario: Submitting the Final Transfer Confirmation form creates a completed export
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
+    And an existing selected series MOCK1
+    And an existing transfer agreement part 1
+    And an existing transfer agreement part 2
     And an existing upload of 3 files
+#    And the file checks are complete
     And 3 of the antivirus scans for the standard transfer have finished
     And 3 of the FFID scans for the standard transfer have finished
     And 3 of the checksum scans for the standard transfer have finished

--- a/src/test/resources/features/ConfirmTransfer.feature
+++ b/src/test/resources/features/ConfirmTransfer.feature
@@ -23,7 +23,6 @@ Feature: Confirm Transfer Page
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
-#    And an existing upload of 3 files
     And the file checks are complete
     And the user is logged in on the Confirm Transfer page
     When the user will be on a page with the title "Confirm transfer"
@@ -36,7 +35,6 @@ Feature: Confirm Transfer Page
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
     And the file checks are complete
-#    And an existing upload of 4 files
     And the user is logged in on the Confirm Transfer page
     When the user will be on a page with the title "Confirm transfer"
     Then the confirm transfer page shows the user that 2 files have been uploaded
@@ -56,10 +54,10 @@ Feature: Confirm Transfer Page
   Scenario: Submitting the Final Transfer Confirmation form creates a completed export
     Given A logged out standard user
     And an existing standard consignment for transferring body MOCK1
-#    And an existing upload of 3 files
     And an existing selected series MOCK1
     And an existing transfer agreement part 1
     And an existing transfer agreement part 2
+    And an existing upload of 2 files
     And the file checks are complete
 #    And 3 of the antivirus scans for the standard transfer have finished
 #    And 3 of the FFID scans for the standard transfer have finished

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -641,7 +641,6 @@ class Steps extends ScalaDsl with EN with Matchers {
 
       val awsUtility = AWSUtility()
 
-      client.updateConsignmentStatus(consignmentId, "ClientChecks", "Completed")
       createdFilesIdToChecksum = addFilesAndMetadataResult.map(res => {
         val info: MatchIdInfo = matchIdInfo.find(_.matchId == res.matchId).get
         awsUtility.uploadFileToS3(configuration.getString("s3.bucket.upload"), s"$consignmentId/${res.fileId}", info.path)

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -641,6 +641,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
       val awsUtility = AWSUtility()
 
+      client.updateConsignmentStatus(consignmentId, "Upload", "Completed")
       client.updateConsignmentStatus(consignmentId, "ClientChecks", "Completed")
       createdFilesIdToChecksum = addFilesAndMetadataResult.map(res => {
         val info: MatchIdInfo = matchIdInfo.find(_.matchId == res.matchId).get

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -640,6 +640,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
       val awsUtility = AWSUtility()
 
+      client.updateConsignmentStatus(consignmentId, "ClientChecks", "Completed")
       createdFilesIdToChecksum = addFilesAndMetadataResult.map(res => {
         val info: MatchIdInfo = matchIdInfo.find(_.matchId == res.matchId).get
         awsUtility.uploadFileToS3(configuration.getString("s3.bucket.upload"), s"$consignmentId/${res.fileId}", info.path)

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -538,6 +538,7 @@ class Steps extends ScalaDsl with EN with Matchers {
     val client = GraphqlUtility(userCredentials)
     client.startUpload(consignmentId)
     client.updateConsignmentStatus(consignmentId, "Upload", "Completed")
+    client.updateConsignmentStatus(consignmentId, "ClientChecks", "Completed")
     val files = List("testfile1", "testfile2")
     val checksumWithIndex: List[MatchIdInfo] = files.zipWithIndex.map({
       case (fileName, idx) =>

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -641,6 +641,7 @@ class Steps extends ScalaDsl with EN with Matchers {
 
       val awsUtility = AWSUtility()
 
+      client.updateConsignmentStatus(consignmentId, "ClientChecks", "Completed")
       createdFilesIdToChecksum = addFilesAndMetadataResult.map(res => {
         val info: MatchIdInfo = matchIdInfo.find(_.matchId == res.matchId).get
         awsUtility.uploadFileToS3(configuration.getString("s3.bucket.upload"), s"$consignmentId/${res.fileId}", info.path)


### PR DESCRIPTION
Only the last scenario actually requires the files to be exported thus I've mainly left it as is. The others just check the contents of the confirm transfer page so I've changed it from `an existing upload of # files` to `the file checks are complete` so we don't have to actually upload to S3 for those scenarios.