### PR TITLE
Adding conditional to run name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
 permissions:
   id-token: write
   contents: read
-run-name: End to end tests (${{ inputs.environment }})
+run-name:  ${{ github.event_name != 'pull_request' && format('End to end tests ({0})', inputs.environment) || '' }}
 jobs:
   setup-e2e-tests:
     concurrency: ${{ github.event.inputs.environment != '' && github.event.inputs.environment || 'intg' }}


### PR DESCRIPTION
Small change to the run-name property in ci.yml so that it outputs default value on a pull request but a custom value when run from a different trigger. 