### PR TITLE
Add export complete step to transfer complete page test

### DIFF
--- a/src/test/resources/features/FileChecks.feature
+++ b/src/test/resources/features/FileChecks.feature
@@ -70,3 +70,4 @@ Feature: File Checks Page
     And 1 of the antivirus scans for the judgment transfer have finished
     Then the user will be on a page with the title "Checking your upload"
     Then the user will be on a page with a panel titled "Transfer complete"
+    And the judgment transfer export will be complete


### PR DESCRIPTION
We've been seeing a lot of export failures in `intg` recently. This behaviour seems to have been introduced by [this](https://github.com/nationalarchives/tdr-e2e-tests/commit/5cafd615057796b8c8bb4ecd6c4fab0d461e7d2d) commit, where an interim page load test (Results of Checks) is removed. This gives less time for the asynchronous consignment export, kicked off after file checks pass, to complete before the scenario finishes. 

When the scenario finishes, it deletes the test user, on which the consignment export is dependent, causing the failures we have seen. Adding the export complete step to this scenario (which waits until the export package is present in s3) should get rid of this noise.