### PR TITLE
TDRD-399 Add Metadata Review e2e test

### DIFF
--- a/.github/scripts/update-waf-ipset.sh
+++ b/.github/scripts/update-waf-ipset.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+IP_SET_NAME="tdr-apps-${2:-intg}-whitelist"
+SCOPE="REGIONAL"
+REGION="eu-west-2"
+NEW_IP=$(curl -s https://ipinfo.io/ip)/32
+
+# Get the current IP set details
+fetch_ip_set_details() {
+  echo "Fetching WAF IPSet details for: $IP_SET_NAME"
+  IP_SET_ID=$(aws wafv2 list-ip-sets --scope "$SCOPE" --region "$REGION" | jq -r --arg ipset_name "$IP_SET_NAME" '.IPSets[] | select(.Name==$ipset_name) | .Id')
+  IP_SET_DETAILS=$(aws wafv2 get-ip-set --name "$IP_SET_NAME" --scope "$SCOPE" --id "$IP_SET_ID" --region "$REGION")
+  EXISTING_IPS=$(echo "$IP_SET_DETAILS" | jq -r '.IPSet.Addresses[]')
+  LOCK_TOKEN=$(echo "$IP_SET_DETAILS" | jq -r '.LockToken')
+}
+
+# Update the IP set with retries on optimistic lock failure
+update_ip_set() {
+  local retries=3
+  local count=0
+  local success=false
+
+  while [ $count -lt $retries ]; do
+    echo "Attempting to update IP set (try $((count + 1))/$retries)..."
+    aws wafv2 update-ip-set --name "$IP_SET_NAME" --scope "$SCOPE" --id "$IP_SET_ID" --addresses $UPDATED_IPS --lock-token "$LOCK_TOKEN" --region "$REGION"
+
+    if [ $? -eq 0 ]; then
+      success=true
+      break
+    else
+      echo "Update failed due to optimistic lock. Retrying..."
+      sleep $((RANDOM % 20 + 10))  # Random sleep between 10 and 30 seconds
+      fetch_ip_set_details
+    fi
+
+    count=$((count + 1))
+  done
+
+  if [ "$success" = true ]; then
+    echo "IP set updated successfully."
+  else
+    echo "Failed to update IP set after $retries attempts."
+    exit 1
+  fi
+}
+
+if [ "$1" = "GET" ]; then
+  fetch_ip_set_details
+  echo "$EXISTING_IPS" > waf-ip.txt
+elif [ "$1" = "INSERT" ]; then
+  fetch_ip_set_details
+  UPDATED_IPS=$(echo "$EXISTING_IPS" | tr '\n' ' ')
+  UPDATED_IPS="$UPDATED_IPS $NEW_IP"
+  update_ip_set
+elif [ "$1" = "DELETE" ]; then
+  fetch_ip_set_details
+  EXISTING_IPS=$(cat waf-ip-artifacts/waf-ip.txt)
+  UPDATED_IPS=$(echo "$EXISTING_IPS" | tr '\n' ' ')
+  update_ip_set
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,25 @@ jobs:
         run: |
           FILES=$(ls src/test/resources/features/ | jq -R -s -c 'split("\n")[:-1]')
           echo files=${FILES} >> $GITHUB_OUTPUT
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets[steps.set-secret-names.outputs.account_number_secret] }}:role/TDRGithubActionsGetE2ESecretsRole${{ steps.set-secret-names.outputs.title_environment }}
+          aws-region: eu-west-2
+          role-session-name: GetKeycloakSecrets
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets[steps.set-secret-names.outputs.account_number_secret] }}:role/TDRUpdateWAFAndSecurityGroupsRole${{ steps.set-secret-names.outputs.title_environment }}
+          aws-region: eu-west-2
+          role-session-name: UpdateWAF
+      - name: Get current IPs from WAF
+        run: .github/scripts/update-waf-ipset.sh GET ${{ github.event.inputs.environment }}
+      - name: Upload WAF IP as artifact
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: waf-ip-artifacts-${{ matrix.file }}
+          path: waf-ip.txt
   run-e2e-tests:
     runs-on: ubuntu-latest
     needs:
@@ -86,6 +105,8 @@ jobs:
           path: ${{ matrix.file }}-ip.txt
       - name: Update security group
         run: .github/scripts/update-security-group.sh INSERT ${{ secrets[needs.setup-e2e-tests.outputs.account_number_secret] }}
+      - name: Update WAF ipset
+        run: .github/scripts/update-waf-ipset.sh INSERT ${{ github.event.inputs.environment }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -117,6 +138,12 @@ jobs:
           path: ip-artifacts
           pattern: ip-artifacts-*
           merge-multiple: true
+      - name: Download WAF IP artifacts
+        uses: actions/download-artifact@v4.1.7
+        with:
+          path: waf-ip-artifacts
+          pattern: waf-ip-artifacts-*
+          merge-multiple: true
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -134,6 +161,8 @@ jobs:
               echo "$ip_file is not a file, skipping..."
             fi
           done
+      - name: Remove WAF ipset
+        run: .github/scripts/update-waf-ipset.sh DELETE ${{ github.event.inputs.environment }}
 
   send-messages:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -179,4 +179,4 @@ or
 % TMPDIR=$HOME/tmp geckodriver
 ```
 Alternatively, geckodriver may be used with a Firefox install that is not packaged inside a sandbox e.g. from mozilla.org.
-Guide on how to [install Firefox via Apt](https://www.omgubuntu.co.uk/2022/04/how-to-install-firefox-deb-apt-ubuntu-22-04).
+Guide on how to [install Firefox via Apt](https://askubuntu.com/questions/1399383/how-to-install-firefox-as-a-traditional-deb-package-without-snap-in-ubuntu-22).

--- a/src/test/resources/features/MetadataReview.feature
+++ b/src/test/resources/features/MetadataReview.feature
@@ -12,39 +12,39 @@ Feature: Metadata review pages
     Then the user will see the alert Your review is in progress
     Then the standard user logs out
     Given A logged in tna user
-    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
-    And the user clicks the Transfers for review button
-    Then the user will be on a page with the title "Metadata Reviews"
-    And the tna user clicks view request for consignment
-    Then the user will be on a page with the label "2. Set the status of this review"
-    And the tna user Approve the metadata
-    And the user clicks the Submit button
-    Then the tna user logs out
-    Given an existing standard user logs in
-    When the logged in user navigates to the review-progress page
-    Then the user will see the alert You can now complete your transfer
+    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service invalid"
+#    And the user clicks the Transfers for review button
+#    Then the user will be on a page with the title "Metadata Reviews"
+#    And the tna user clicks view request for consignment
+#    Then the user will be on a page with the label "2. Set the status of this review"
+#    And the tna user Approve the metadata
+#    And the user clicks the Submit button
+#    Then the tna user logs out
+#    Given an existing standard user logs in
+#    When the logged in user navigates to the review-progress page
+#    Then the user will see the alert You can now complete your transfer
 
 
-  Scenario: Metadata review requested by user is rejected by DTA reviewer
-    Given A logged in standard user
-    And an existing standard consignment for transferring body MOCK1
-    And an existing upload of 2 files
-    And an existing completed closure form
-    And the logged in user navigates to the Download Metadata page
-    When the user clicks the continue button
-    Then the user will be on a page with the large heading "Request a metadata review"
-    When the user clicks the Submit Metadata for review button
-    Then the user will see the alert Your review is in progress
-    Then the standard user logs out
-    Given A logged in tna user
-    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
-    And the user clicks the Transfers for review button
-    Then the user will be on a page with the title "Metadata Reviews"
-    And the tna user clicks view request for consignment
-    Then the user will be on a page with the label "2. Set the status of this review"
-    And the tna user Reject the metadata
-    And the user clicks the Submit button
-    Then the tna user logs out
-    Given an existing standard user logs in
-    When the logged in user navigates to the review-progress page
-    Then the user will see the alert We found issues in your metadata
+#  Scenario: Metadata review requested by user is rejected by DTA reviewer
+#    Given A logged in standard user
+#    And an existing standard consignment for transferring body MOCK1
+#    And an existing upload of 2 files
+#    And an existing completed closure form
+#    And the logged in user navigates to the Download Metadata page
+#    When the user clicks the continue button
+#    Then the user will be on a page with the large heading "Request a metadata review"
+#    When the user clicks the Submit Metadata for review button
+#    Then the user will see the alert Your review is in progress
+#    Then the standard user logs out
+#    Given A logged in tna user
+#    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
+#    And the user clicks the Transfers for review button
+#    Then the user will be on a page with the title "Metadata Reviews"
+#    And the tna user clicks view request for consignment
+#    Then the user will be on a page with the label "2. Set the status of this review"
+#    And the tna user Reject the metadata
+#    And the user clicks the Submit button
+#    Then the tna user logs out
+#    Given an existing standard user logs in
+#    When the logged in user navigates to the review-progress page
+#    Then the user will see the alert We found issues in your metadata

--- a/src/test/resources/features/MetadataReview.feature
+++ b/src/test/resources/features/MetadataReview.feature
@@ -1,5 +1,4 @@
 Feature: Metadata review pages
-
   Scenario: Metadata review requested by user is approved by DTA reviewer
     Given A logged in standard user
     And an existing standard consignment for transferring body MOCK1
@@ -11,19 +10,18 @@ Feature: Metadata review pages
     When the user clicks the Submit Metadata for review button
     Then the user will see the alert Your review is in progress
     Then the standard user logs out
-    Given A logged in tna user
+    Given A logged in transfer adviser user
     Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
     And the user clicks the Transfers for review button
     Then the user will be on a page with the title "Metadata Reviews"
-    And the tna user clicks view request for consignment
+    And the transfer adviser user clicks view request for consignment
     Then the user will be on a page with the label "2. Set the status of this review"
-    And the tna user Approve the metadata
+    And the transfer adviser user Approve the metadata
     And the user clicks the Submit button
-    Then the tna user logs out
+    Then the transfer adviser user logs out
     Given an existing standard user logs in
     When the logged in user navigates to the review-progress page
     Then the user will see the alert You can now complete your transfer
-
 
   Scenario: Metadata review requested by user is rejected by DTA reviewer
     Given A logged in standard user
@@ -36,15 +34,15 @@ Feature: Metadata review pages
     When the user clicks the Submit Metadata for review button
     Then the user will see the alert Your review is in progress
     Then the standard user logs out
-    Given A logged in tna user
+    Given A logged in transfer adviser user
     Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
     And the user clicks the Transfers for review button
     Then the user will be on a page with the title "Metadata Reviews"
-    And the tna user clicks view request for consignment
+    And the transfer adviser user clicks view request for consignment
     Then the user will be on a page with the label "2. Set the status of this review"
-    And the tna user Reject the metadata
+    And the transfer adviser user Reject the metadata
     And the user clicks the Submit button
-    Then the tna user logs out
+    Then the transfer adviser user logs out
     Given an existing standard user logs in
     When the logged in user navigates to the review-progress page
     Then the user will see the alert We found issues in your metadata

--- a/src/test/resources/features/MetadataReview.feature
+++ b/src/test/resources/features/MetadataReview.feature
@@ -25,26 +25,26 @@ Feature: Metadata review pages
     Then the user will see the alert You can now complete your transfer
 
 
-#  Scenario: Metadata review requested by user is rejected by DTA reviewer
-#    Given A logged in standard user
-#    And an existing standard consignment for transferring body MOCK1
-#    And an existing upload of 2 files
-#    And an existing completed closure form
-#    And the logged in user navigates to the Download Metadata page
-#    When the user clicks the continue button
-#    Then the user will be on a page with the large heading "Request a metadata review"
-#    When the user clicks the Submit Metadata for review button
-#    Then the user will see the alert Your review is in progress
-#    Then the standard user logs out
-#    Given A logged in tna user
-#    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
-#    And the user clicks the Transfers for review button
-#    Then the user will be on a page with the title "Metadata Reviews"
-#    And the tna user clicks view request for consignment
-#    Then the user will be on a page with the label "2. Set the status of this review"
-#    And the tna user Reject the metadata
-#    And the user clicks the Submit button
-#    Then the tna user logs out
-#    Given an existing standard user logs in
-#    When the logged in user navigates to the review-progress page
-#    Then the user will see the alert We found issues in your metadata
+  Scenario: Metadata review requested by user is rejected by DTA reviewer
+    Given A logged in standard user
+    And an existing standard consignment for transferring body MOCK1
+    And an existing upload of 2 files
+    And an existing completed closure form
+    And the logged in user navigates to the Download Metadata page
+    When the user clicks the continue button
+    Then the user will be on a page with the large heading "Request a metadata review"
+    When the user clicks the Submit Metadata for review button
+    Then the user will see the alert Your review is in progress
+    Then the standard user logs out
+    Given A logged in tna user
+    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
+    And the user clicks the Transfers for review button
+    Then the user will be on a page with the title "Metadata Reviews"
+    And the tna user clicks view request for consignment
+    Then the user will be on a page with the label "2. Set the status of this review"
+    And the tna user Reject the metadata
+    And the user clicks the Submit button
+    Then the tna user logs out
+    Given an existing standard user logs in
+    When the logged in user navigates to the review-progress page
+    Then the user will see the alert We found issues in your metadata

--- a/src/test/resources/features/MetadataReview.feature
+++ b/src/test/resources/features/MetadataReview.feature
@@ -1,0 +1,50 @@
+Feature: Metadata review pages
+
+  Scenario: Metadata review requested by user is approved by DTA reviewer
+    Given A logged in standard user
+    And an existing standard consignment for transferring body MOCK1
+    And an existing upload of 2 files
+    And an existing completed closure form
+    And the logged in user navigates to the Download Metadata page
+    When the user clicks the continue button
+    Then the user will be on a page with the large heading "Request a metadata review"
+    When the user clicks the Submit Metadata for review button
+    Then the user will see the alert Your review is in progress
+    Then the standard user logs out
+    Given A logged in tna user
+    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
+    And the user clicks the Transfers for review button
+    Then the user will be on a page with the title "Metadata Reviews"
+    And the tna user clicks view request for consignment
+    Then the user will be on a page with the label "2. Set the status of this review"
+    And the tna user Approve the metadata
+    And the user clicks the Submit button
+    Then the tna user logs out
+    Given an existing standard user logs in
+    When the logged in user navigates to the review-progress page
+    Then the user will see the alert You can now complete your transfer
+
+
+  Scenario: Metadata review requested by user is rejected by DTA reviewer
+    Given A logged in standard user
+    And an existing standard consignment for transferring body MOCK1
+    And an existing upload of 2 files
+    And an existing completed closure form
+    And the logged in user navigates to the Download Metadata page
+    When the user clicks the continue button
+    Then the user will be on a page with the large heading "Request a metadata review"
+    When the user clicks the Submit Metadata for review button
+    Then the user will see the alert Your review is in progress
+    Then the standard user logs out
+    Given A logged in tna user
+    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
+    And the user clicks the Transfers for review button
+    Then the user will be on a page with the title "Metadata Reviews"
+    And the tna user clicks view request for consignment
+    Then the user will be on a page with the label "2. Set the status of this review"
+    And the tna user Reject the metadata
+    And the user clicks the Submit button
+    Then the tna user logs out
+    Given an existing standard user logs in
+    When the logged in user navigates to the review-progress page
+    Then the user will see the alert We found issues in your metadata

--- a/src/test/resources/features/MetadataReview.feature
+++ b/src/test/resources/features/MetadataReview.feature
@@ -12,17 +12,17 @@ Feature: Metadata review pages
     Then the user will see the alert Your review is in progress
     Then the standard user logs out
     Given A logged in tna user
-    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service invalid"
-#    And the user clicks the Transfers for review button
-#    Then the user will be on a page with the title "Metadata Reviews"
-#    And the tna user clicks view request for consignment
-#    Then the user will be on a page with the label "2. Set the status of this review"
-#    And the tna user Approve the metadata
-#    And the user clicks the Submit button
-#    Then the tna user logs out
-#    Given an existing standard user logs in
-#    When the logged in user navigates to the review-progress page
-#    Then the user will see the alert You can now complete your transfer
+    Then the user will be on a page with the title "Welcome to the Transfer Digital Records service"
+    And the user clicks the Transfers for review button
+    Then the user will be on a page with the title "Metadata Reviews"
+    And the tna user clicks view request for consignment
+    Then the user will be on a page with the label "2. Set the status of this review"
+    And the tna user Approve the metadata
+    And the user clicks the Submit button
+    Then the tna user logs out
+    Given an existing standard user logs in
+    When the logged in user navigates to the review-progress page
+    Then the user will see the alert You can now complete your transfer
 
 
 #  Scenario: Metadata review requested by user is rejected by DTA reviewer

--- a/src/test/scala/helpers/steps/StepsUtility.scala
+++ b/src/test/scala/helpers/steps/StepsUtility.scala
@@ -24,7 +24,7 @@ object StepsUtility {
       so it doesn't matter if the same element on the first page has disappeared.*/
       .until((driver: WebDriver) => {
         val panels: List[WebElement] = webDriver.findElements(By.className(elementClassName)).asScala.toList
-        println(${webDriver.getPageSource})
+        println("Last page: " + webDriver.getPageSource)
         panels.exists(_.getText == title)
       })
   }

--- a/src/test/scala/helpers/steps/StepsUtility.scala
+++ b/src/test/scala/helpers/steps/StepsUtility.scala
@@ -24,6 +24,7 @@ object StepsUtility {
       so it doesn't matter if the same element on the first page has disappeared.*/
       .until((driver: WebDriver) => {
         val panels: List[WebElement] = webDriver.findElements(By.className(elementClassName)).asScala.toList
+        println(${webDriver.getPageSource})
         panels.exists(_.getText == title)
       })
   }

--- a/src/test/scala/helpers/steps/StepsUtility.scala
+++ b/src/test/scala/helpers/steps/StepsUtility.scala
@@ -24,7 +24,6 @@ object StepsUtility {
       so it doesn't matter if the same element on the first page has disappeared.*/
       .until((driver: WebDriver) => {
         val panels: List[WebElement] = webDriver.findElements(By.className(elementClassName)).asScala.toList
-        println("Last page: " + webDriver.getPageSource)
         panels.exists(_.getText == title)
       })
   }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -43,12 +43,14 @@ class Steps extends ScalaDsl with EN {
   val authUrl: String = configuration.getString("tdr.auth.url")
   val email: String = s"${RandomUtility.randomString()}@testSomething.com"
   val differentEmail: String = s"${RandomUtility.randomString()}@testSomething.com"
+  val tnaEmail: String = s"e2eTNAUser${RandomUtility.randomString(2)}@testSomething.com"
   val invalidEmail: String = "dgfhfdgjhgfj"
   val password: String = RandomUtility.randomString(10)
   val differentPassword: String = RandomUtility.randomString(10)
   val invalidPassword: String = "fdghfdgh"
   val userCredentials: UserCredentials = UserCredentials(email, password)
   val differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
+  val tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, differentPassword)
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
 
@@ -190,7 +192,7 @@ class Steps extends ScalaDsl with EN {
   Given("^A logged in (.*) user") {
     userType: String =>
       val credential = userType match {
-        case "tna" => differentUserCredentials
+        case "tna" => tnaUserCredentials
         case _ => userCredentials
       }
       userId = KeycloakClient.createUser(credential, Some("Mock 1 Department"), Some(userType))
@@ -207,7 +209,6 @@ class Steps extends ScalaDsl with EN {
     _: String =>
       val client = GraphqlUtility(userCredentials)
       consignmentRef = client.getConsignmentReference(consignmentId)
-      Thread.sleep(1000)
       logout()
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -43,14 +43,12 @@ class Steps extends ScalaDsl with EN {
   val authUrl: String = configuration.getString("tdr.auth.url")
   val email: String = s"${RandomUtility.randomString()}@testSomething.com"
   val differentEmail: String = s"${RandomUtility.randomString()}@testSomething.com"
-  val tnaEmail: String = s"e2eTNAUser${RandomUtility.randomString(2)}@testSomething.com"
   val invalidEmail: String = "dgfhfdgjhgfj"
   val password: String = RandomUtility.randomString(10)
   val differentPassword: String = RandomUtility.randomString(10)
   val invalidPassword: String = "fdghfdgh"
   val userCredentials: UserCredentials = UserCredentials(email, password)
   val differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
-  val tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, differentPassword)
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
 
@@ -192,7 +190,7 @@ class Steps extends ScalaDsl with EN {
   Given("^A logged in (.*) user") {
     userType: String =>
       val credential = userType match {
-        case "tna" => tnaUserCredentials
+        case "tna" => differentUserCredentials
         case _ => userCredentials
       }
       userId = KeycloakClient.createUser(credential, Some("Mock 1 Department"), Some(userType))

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -15,7 +15,6 @@ import io.cucumber.scala.{EN, ScalaDsl, Scenario}
 import org.junit.Assert
 import org.openqa.selenium._
 import org.openqa.selenium.support.ui.{ExpectedConditions, FluentWait, Select, WebDriverWait}
-import org.scalatest.matchers.should.Matchers._
 
 import java.io.File
 import java.nio.file.Paths
@@ -32,6 +31,7 @@ class Steps extends ScalaDsl with EN {
   var userType: String = ""
   var differentUserId: String = ""
   var consignmentId: UUID = _
+  var consignmentRef: String = _
   var createdFiles: List[UUID] = _
   var createdFilesIdToChecksum: Map[UUID, String] = Map()
   var filesWithoutAVMetadata: List[UUID] = _
@@ -74,16 +74,27 @@ class Steps extends ScalaDsl with EN {
     StepsUtility.userLogin(webDriver, userCredentials)
   }
 
+  private def logout(): Unit = {
+    Try {
+      val signOutElement = webDriver.findElement(By.cssSelector("header[role='banner'] li:nth-child(2) a:nth-child(1)"))
+      signOutElement.click()
+    }.recover {
+      case _: NoSuchElementException =>
+        webDriver.findElement(By.cssSelector("a[class='govuk-header__link']")).click()
+    }
+  }
+
   private def loadPage(page: String): Unit = {
     val hyphenatedPageName = page.toLowerCase.replaceAll(" ", "-")
     val isJudgment = userType == "judgment"
-    val path = if(isJudgment) "judgment" else "consignment"
+    val path = if (isJudgment) "judgment" else "consignment"
     val pageWithConsignment = hyphenatedPageName match {
       case "homepage" | "view-transfers" | "some-page" => s"$baseUrl/$hyphenatedPageName"
-      case "faq" | "help" => if(isJudgment) s"$baseUrl/$path/$hyphenatedPageName" else s"$baseUrl/$hyphenatedPageName"
+      case "faq" | "help" => if (isJudgment) s"$baseUrl/$path/$hyphenatedPageName" else s"$baseUrl/$hyphenatedPageName"
       case "download-metadata" => s"$baseUrl/$path/$consignmentId/additional-metadata/$hyphenatedPageName"
       case "additional-metadata-entry" => s"$baseUrl/$path/$consignmentId/additional-metadata/entry-method"
       case "draft-metadata-upload" => s"$baseUrl/$path/$consignmentId/draft-metadata/upload"
+      case "review-progress" => s"$baseUrl/$path/$consignmentId/metadata-review/review-progress"
       case _ => s"$baseUrl/$path/$consignmentId/$hyphenatedPageName"
     }
     webDriver.get(pageWithConsignment)
@@ -178,9 +189,25 @@ class Steps extends ScalaDsl with EN {
 
   Given("^A logged in (.*) user") {
     userType: String =>
-      userId = KeycloakClient.createUser(userCredentials, Some("Mock 1 Department"), Some(userType))
-      login(userCredentials)
+      val credential = userType match {
+        case "tna" => differentUserCredentials
+        case _ => userCredentials
+      }
+      userId = KeycloakClient.createUser(credential, Some("Mock 1 Department"), Some(userType))
+      login(credential)
       this.userType = userType
+  }
+
+  Given("^an existing (.*) user logs in") {
+    userType: String =>
+      login(userCredentials)
+  }
+
+  Then("^the (.*) user logs out") {
+    _: String =>
+      val client = GraphqlUtility(userCredentials)
+      consignmentRef = client.getConsignmentReference(consignmentId)
+      logout()
   }
 
   And("^the user is logged in on the (.*) page") {
@@ -349,6 +376,16 @@ class Steps extends ScalaDsl with EN {
       StepsUtility.waitForElementTitle(webDriver, title, "govuk-heading-l")
   }
 
+  Then("^the user will be on a page with the label \"(.*)\"") {
+    page: String =>
+      StepsUtility.waitForElementTitle(webDriver, page, "govuk-label")
+  }
+
+  Then("^the user will see the alert (.*)") {
+    text: String =>
+      StepsUtility.waitForElementTitle(webDriver, text, "da-alert__heading")
+  }
+
   And("^the user will see a row with a consignment reference that correlates with their consignmentId") {
     () =>
       val client = GraphqlUtility(userCredentials)
@@ -440,6 +477,12 @@ class Steps extends ScalaDsl with EN {
     selectedSeries: String =>
       val seriesDropdown = new Select(webDriver.findElement(By.name("series")))
       seriesDropdown.selectByVisibleText(selectedSeries)
+  }
+
+  And("^the (.*) user (.*) the metadata") {
+    (userType: String, status: String) =>
+      val statusDropdown = new Select(webDriver.findElement(By.name("status")))
+      statusDropdown.selectByVisibleText(status)
   }
 
   And("^the user selects the option (.*)") {
@@ -1018,5 +1061,23 @@ class Steps extends ScalaDsl with EN {
     (status: String) =>
       val value = webDriver.findElement(By.cssSelector(".govuk-summary-list__value .govuk-tag")).getText
       Assert.assertEquals(status, value)
+  }
+
+  And("^the (.*) user clicks view request for consignment") {
+    (userType: String) =>
+      val rows: List[WebElement] = webDriver.findElements(By.cssSelector("tr.govuk-table__row")).asScala.toList
+      var found = false  // Boolean flag to control the loop
+
+      // Iterate through the rows to find the one with the header consignmentRef
+      for (row <- rows if !found) {
+        val header: WebElement = row.findElement(By.cssSelector("th.govuk-table__header"))
+
+        if (header.getText.contains(consignmentRef)) {
+          // Once found, click the "View request" link within that row
+          val viewRequestLink: WebElement = row.findElement(By.cssSelector("a.govuk-link"))
+          viewRequestLink.click()
+          found = true
+        }
+      }
   }
 }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -207,6 +207,7 @@ class Steps extends ScalaDsl with EN {
     _: String =>
       val client = GraphqlUtility(userCredentials)
       consignmentRef = client.getConsignmentReference(consignmentId)
+      Thread.sleep(1000)
       logout()
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -189,11 +189,14 @@ class Steps extends ScalaDsl with EN {
 
   Given("^A logged in (.*) user") {
     userType: String =>
-      val credential = userType match {
-        case "tna" => differentUserCredentials
-        case _ => userCredentials
+      val credential: UserCredentials = userType match {
+        case "transfer adviser" | "metadata viewer" =>
+          userId = KeycloakClient.createUser(differentUserCredentials, None, Some(userType.replace(" ", "_")))
+          differentUserCredentials
+        case _ =>
+          userId = KeycloakClient.createUser(userCredentials, Some("Mock 1 Department"), Some(userType))
+          userCredentials
       }
-      userId = KeycloakClient.createUser(credential, Some("Mock 1 Department"), Some(userType))
       login(credential)
       this.userType = userType
   }


### PR DESCRIPTION
- Added new update-waf-script to add github runner ips to the IPSetlist in order to test pages under `/admin` path
- Updated `ci.yml` to call update-waf-script to add/remove IPs

Requires PR: 
- https://github.com/nationalarchives/tdr-terraform-environments/pull/509 
- https://github.com/nationalarchives/tdr-keycloak-user-management/pull/405

A few issues I noticed:
* Feature tests will fail more than usual as they can sometimes fail due to optimistic locking (I tried to mitigate this by having retries & sleeps in the script)
* When new E2E tests run concurrently it causes issues with retaining the original IPSet which we need when we remove the added IPs because others are updating it as others are reading.

We can either
- Merge this pr and deal with the issues if we really want to test metadata review
- Wait until we move the e2e tests to the enterprise edition so we can have a static IP address