### PR TITLE
TDRD-521: incl feature/scenario in user last/first name

### DIFF
--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -52,13 +52,13 @@ class Steps extends ScalaDsl with EN {
   val differentPassword: String = RandomUtility.randomString(10)
   val tnaPassword: String = RandomUtility.randomString(10)
   val invalidPassword: String = "fdghfdgh"
-//  var userCredentials: UserCredentials = _
-//  var differentUserCredentials: UserCredentials = _
-//  var tnaUserCredentials: UserCredentials = _
+  var userCredentials: UserCredentials = _
+  var differentUserCredentials: UserCredentials = _
+  var tnaUserCredentials: UserCredentials = _
 
-  var userCredentials: UserCredentials = UserCredentials(email, password)
-  var differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
-  var tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
+//  var userCredentials: UserCredentials = UserCredentials(email, password)
+//  var differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
+//  var tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
 
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
@@ -74,13 +74,13 @@ class Steps extends ScalaDsl with EN {
     val featureName = scenario.getUri.toURL.getFile.split('/').last
     val scenarioName = scenario.getName.take(250).replaceAll("[^a-zA-Z0-9]+"," ")
 
-    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
-    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
-    tnaUserCredentials = tnaUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+//    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+//    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+//    tnaUserCredentials = tnaUserCredentials.copy(lastName = featureName, firstName = scenarioName)
 
-//    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
-//    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
-//    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
+    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
+    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
+    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
   }
 
   After { scenario : Scenario =>

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -60,6 +60,8 @@ class Steps extends ScalaDsl with EN {
   def waitTime(n: Long): Duration = { Duration.ofSeconds(n)}
 
   Before { scenario : Scenario =>
+    val name = scenario.getName
+    println("===> " + name)
     webDriver = initDriver
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -61,7 +61,7 @@ class Steps extends ScalaDsl with EN {
   def waitTime(n: Long): Duration = { Duration.ofSeconds(n)}
 
   Before { scenario : Scenario =>
-    val featureName = scenario.getUri.toURL.getFile.split(".").head.take(250)
+    val featureName = scenario.getUri.toURL.getFile.take(250)
     val scenarioName = scenario.getName.take(250)
     println("===> " + featureName.take(250))
     println("===> " + scenarioName.take(250))

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -62,7 +62,7 @@ class Steps extends ScalaDsl with EN {
 
   Before { scenario : Scenario =>
     val featureName = scenario.getUri.toURL.getFile.split('/').last
-    val scenarioName = scenario.getName.take(250)
+    val scenarioName = scenario.getName.take(250).replaceAll("[^a-zA-Z0-9]+"," ")
     println("===> " + featureName)
     println("===> " + scenarioName)
     userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -18,6 +18,7 @@ import org.openqa.selenium._
 import org.openqa.selenium.support.ui.{ExpectedConditions, FluentWait, Select, WebDriverWait}
 
 import java.io.{BufferedOutputStream, File, FileOutputStream}
+import java.net.URI
 import java.nio.file.Paths
 import java.time.Duration
 import java.util
@@ -51,21 +52,22 @@ class Steps extends ScalaDsl with EN {
   val differentPassword: String = RandomUtility.randomString(10)
   val tnaPassword: String = RandomUtility.randomString(10)
   val invalidPassword: String = "fdghfdgh"
-  val userCredentials: UserCredentials = UserCredentials(email, password)
-  val differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
-  val tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
+  var userCredentials: UserCredentials = UserCredentials(email, password)
+  var differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
+  var tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
 
   def waitTime(n: Long): Duration = { Duration.ofSeconds(n)}
 
   Before { scenario : Scenario =>
-    val featureName = scenario.getId.split(";").head.replace("-"," ")
-    val featureNameAgain = scenario.getUri.toString
-    val scenarioName = scenario.getName
-
-    println("===> " + featureNameAgain.take(250))
+    val featureName = scenario.getUri.toURL.getFile.split(".").head.take(250)
+    val scenarioName = scenario.getName.take(250)
+    println("===> " + featureName.take(250))
     println("===> " + scenarioName.take(250))
+    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
     webDriver = initDriver
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -55,11 +55,6 @@ class Steps extends ScalaDsl with EN {
   var userCredentials: UserCredentials = _
   var differentUserCredentials: UserCredentials = _
   var tnaUserCredentials: UserCredentials = _
-
-//  var userCredentials: UserCredentials = UserCredentials(email, password)
-//  var differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
-//  var tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
-
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
 
@@ -68,19 +63,6 @@ class Steps extends ScalaDsl with EN {
   Before { scenario : Scenario =>
     setUserCredentialsForScenario(scenario)
     webDriver = initDriver
-  }
-
-  private def setUserCredentialsForScenario(scenario: Scenario): Unit = {
-    val featureName = scenario.getUri.toURL.getFile.split('/').last
-    val scenarioName = scenario.getName.take(250).replaceAll("[^a-zA-Z0-9]+"," ")
-
-//    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
-//    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
-//    tnaUserCredentials = tnaUserCredentials.copy(lastName = featureName, firstName = scenarioName)
-
-    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
-    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
-    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
   }
 
   After { scenario : Scenario =>
@@ -139,6 +121,14 @@ class Steps extends ScalaDsl with EN {
       case _ => s"$baseUrl/consignment/$consignmentId/$hyphenatedPageName"
     }
     webDriver.get(pageWithConsignment)
+  }
+
+  private def setUserCredentialsForScenario(scenario: Scenario): Unit = {
+    val featureName = scenario.getUri.toURL.getFile.split('/').last
+    val scenarioName = scenario.getName.take(250).replaceAll("[^a-zA-Z0-9]+"," ")
+    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
+    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
+    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
   }
 
   private def userCleanUp(): Unit = {

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -74,8 +74,6 @@ class Steps extends ScalaDsl with EN {
     def toScalaList: List[WebElement] = javaList.asScala.toList
   }
 
-
-
   private def login(userCredentials: UserCredentials): Unit = {
     webDriver.get(s"$baseUrl")
     val startElement = webDriver.findElement(By.cssSelector(".govuk-button--start"))

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -52,9 +52,14 @@ class Steps extends ScalaDsl with EN {
   val differentPassword: String = RandomUtility.randomString(10)
   val tnaPassword: String = RandomUtility.randomString(10)
   val invalidPassword: String = "fdghfdgh"
-  var userCredentials: UserCredentials = _
-  var differentUserCredentials: UserCredentials = _
-  var tnaUserCredentials: UserCredentials = _
+//  var userCredentials: UserCredentials = _
+//  var differentUserCredentials: UserCredentials = _
+//  var tnaUserCredentials: UserCredentials = _
+
+  var userCredentials: UserCredentials = UserCredentials(email, password)
+  var differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
+  var tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
+
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
 
@@ -68,9 +73,14 @@ class Steps extends ScalaDsl with EN {
   private def setUserCredentialsForScenario(scenario: Scenario): Unit = {
     val featureName = scenario.getUri.toURL.getFile.split('/').last
     val scenarioName = scenario.getName.take(250).replaceAll("[^a-zA-Z0-9]+"," ")
-    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
-    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
-    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
+
+    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+    tnaUserCredentials = tnaUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+
+//    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
+//    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
+//    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
   }
 
   After { scenario : Scenario =>

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -61,9 +61,10 @@ class Steps extends ScalaDsl with EN {
 
   Before { scenario : Scenario =>
     val featureName = scenario.getId.split(";").head.replace("-"," ")
+    val featureNameAgain = scenario.getUri.toString
     val scenarioName = scenario.getName
 
-    println("===> " + featureName.take(250))
+    println("===> " + featureNameAgain.take(250))
     println("===> " + scenarioName.take(250))
     webDriver = initDriver
   }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -52,23 +52,25 @@ class Steps extends ScalaDsl with EN {
   val differentPassword: String = RandomUtility.randomString(10)
   val tnaPassword: String = RandomUtility.randomString(10)
   val invalidPassword: String = "fdghfdgh"
-  var userCredentials: UserCredentials = UserCredentials(email, password)
-  var differentUserCredentials: UserCredentials = UserCredentials(differentEmail, differentPassword)
-  var tnaUserCredentials: UserCredentials = UserCredentials(tnaEmail, tnaPassword)
+  var userCredentials: UserCredentials = _
+  var differentUserCredentials: UserCredentials = _
+  var tnaUserCredentials: UserCredentials = _
   val invalidUserCredentials: UserCredentials = UserCredentials(invalidEmail, invalidPassword)
   val checksumValue = "checksum"
 
   def waitTime(n: Long): Duration = { Duration.ofSeconds(n)}
 
   Before { scenario : Scenario =>
+    setUserCredentialsForScenario(scenario)
+    webDriver = initDriver
+  }
+
+  private def setUserCredentialsForScenario(scenario: Scenario): Unit = {
     val featureName = scenario.getUri.toURL.getFile.split('/').last
     val scenarioName = scenario.getName.take(250).replaceAll("[^a-zA-Z0-9]+"," ")
-    println("===> " + featureName)
-    println("===> " + scenarioName)
-    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
-    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
-    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
-    webDriver = initDriver
+    userCredentials = UserCredentials(email, password, lastName = featureName, firstName = scenarioName)
+    differentUserCredentials = UserCredentials(differentEmail, differentPassword, lastName = featureName, firstName = scenarioName)
+    tnaUserCredentials = UserCredentials(tnaEmail, tnaPassword, lastName = featureName, firstName = scenarioName)
   }
 
   After { scenario : Scenario =>
@@ -79,6 +81,8 @@ class Steps extends ScalaDsl with EN {
   implicit class JavaWebElementList(javaList: util.List[WebElement]) {
     def toScalaList: List[WebElement] = javaList.asScala.toList
   }
+
+
 
   private def login(userCredentials: UserCredentials): Unit = {
     webDriver.get(s"$baseUrl")

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -243,7 +243,7 @@ class Steps extends ScalaDsl with EN {
 
   Then("^the (.*) user logs out") {
     _: String =>
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       consignmentRef = client.getConsignmentReference(consignmentId)
       logout()
   }
@@ -374,7 +374,7 @@ class Steps extends ScalaDsl with EN {
 
   And("^the (.*) transfer export will be complete") {
     consignmentType: String =>
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     val consignmentRef = client.getConsignmentExport(consignmentId).get.getConsignment.get.consignmentReference
 
     val fluentWait = new FluentWait[WebDriver](webDriver)
@@ -441,7 +441,7 @@ class Steps extends ScalaDsl with EN {
 
   And("^the user will see a row with a consignment reference that correlates with their consignmentId") {
     () =>
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       val consignmentRef = client.getConsignmentReference(consignmentId)
       StepsUtility.waitForElementTitle(webDriver, s"$consignmentRef", "govuk-table__header")
   }
@@ -566,7 +566,7 @@ class Steps extends ScalaDsl with EN {
         val linkClass = linkName.toLowerCase.replaceAll(" ", "-")
         val link = webDriver.findElement(By.cssSelector(s"a.$linkClass"))
         link.click()
-        val client = GraphqlUtility(userCredentials)
+        lazy val client = GraphqlUtility(userCredentials)
         val consignmentRef = client.getConsignmentReference(consignmentId)
         val filteredFiles = getDownloadedCsv(consignmentRef)
 
@@ -647,29 +647,29 @@ class Steps extends ScalaDsl with EN {
 
   And("^an existing (.*) consignment for transferring body (.*)") {
     (consignmentType:String, body: String) =>
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       consignmentId = client.createConsignment(consignmentType, body).get.addConsignment.consignmentid.get
   }
 
   And("^an existing selected series (.*)") {
     (body: String) =>
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     client.addConsignmentStatus(consignmentId, "Series", "Completed")
     client.updateSeries(consignmentId, body)
   }
 
   And("^an existing transfer agreement part 1") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     client.createTransferAgreementPrivateBeta(consignmentId)
   }
 
   And("^an existing transfer agreement part 2") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     client.createTransferAgreementCompliance(consignmentId)
   }
 
   And("^the file checks are complete") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     client.startUpload(consignmentId)
     client.updateConsignmentStatus(consignmentId, "Upload", "Completed")
     client.updateConsignmentStatus(consignmentId, "ClientChecks", "Completed")
@@ -693,7 +693,7 @@ class Steps extends ScalaDsl with EN {
   }
 
   And("^the (checksum|antivirus|FFID) check has (.*)") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     (checkName: String, result: String) => {
       val matchIdInfo = List(MatchIdInfo(checksumValue, Paths.get("."), 0))
       val id = client.addFilesAndMetadata(consignmentId, "E2E TEST UPLOAD FOLDER", matchIdInfo).map(_.fileId).head
@@ -712,7 +712,7 @@ class Steps extends ScalaDsl with EN {
 
   And("^the FFID \"(.*)\" check has failed") {
     (checkName: String) => {
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       val matchIdInfo = List(MatchIdInfo(checksumValue, Paths.get("."), 0))
       val id: UUID = client.addFilesAndMetadata(consignmentId, "E2E TEST UPLOAD FOLDER", matchIdInfo).map(_.fileId).head
       val statusValue = checkName match {
@@ -724,13 +724,13 @@ class Steps extends ScalaDsl with EN {
   }
 
   And("^the user has created additional metadata") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     client.createCustomMetadata(consignmentId)
   }
 
   Then("^the metadata csv will have the correct columns for (.*) files") {
     numberOfFiles: Int =>
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       val consignmentRef = client.getConsignmentReference(consignmentId)
       val metadataCsv = getDownloadedCsv(consignmentRef).last
       val source = Source.fromFile(metadataCsv.getAbsolutePath)
@@ -762,7 +762,7 @@ class Steps extends ScalaDsl with EN {
 
   Then("^the downloaded metadata csv should be same as (.*)") {
     fileName: String =>
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       val consignmentRef = client.getConsignmentReference(consignmentId)
       val metadataCsv = getDownloadedCsv(consignmentRef).last
       val source = Source.fromFile(metadataCsv.getAbsolutePath)
@@ -787,7 +787,7 @@ class Steps extends ScalaDsl with EN {
   }
 
   And("^an existing upload of (\\d+) files") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     numberOfFiles: Int => {
       val files = List("testfile1.txt", "testfile2.txt")
 
@@ -812,7 +812,7 @@ class Steps extends ScalaDsl with EN {
   }
 
   And("^(\\d+) of the (.*) scans for the (.*) transfer have finished") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     (filesToProcess: Int, metadataType: String, consignmentType: String) => {
       val fileRangeToProcess = createdFiles.slice(0, filesToProcess)
       metadataType match {
@@ -840,7 +840,7 @@ class Steps extends ScalaDsl with EN {
   }
 
   And("^the user waits for the checks to complete") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     filesWithoutChecksumMetadata.foreach {
       id =>
         client.createBackendChecksumMetadata(consignmentId, List(id), createdFilesIdToChecksum.get(id))
@@ -1106,12 +1106,12 @@ class Steps extends ScalaDsl with EN {
 
   And("^an existing completed (.*) form") {
     (metadataType: String) =>
-      val client = GraphqlUtility(userCredentials)
+      lazy val client = GraphqlUtility(userCredentials)
       client.saveMetadata(consignmentId, createdFiles, metadataType)
   }
 
   And("^an existing metadata review is in progress") {
-    val client = GraphqlUtility(userCredentials)
+    lazy val client = GraphqlUtility(userCredentials)
     val updateStatus = client.addConsignmentStatus(consignmentId, "MetadataReview", "InProgress")
     Assert.assertTrue(updateStatus.nonEmpty)
   }

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -60,8 +60,11 @@ class Steps extends ScalaDsl with EN {
   def waitTime(n: Long): Duration = { Duration.ofSeconds(n)}
 
   Before { scenario : Scenario =>
-    val name = scenario.getName
-    println("===> " + name)
+    val featureName = scenario.getId.split(";").head.replace("-"," ")
+    val scenarioName = scenario.getName
+
+    println("===> " + featureName.take(250))
+    println("===> " + scenarioName.take(250))
     webDriver = initDriver
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -61,13 +61,13 @@ class Steps extends ScalaDsl with EN {
   def waitTime(n: Long): Duration = { Duration.ofSeconds(n)}
 
   Before { scenario : Scenario =>
-    val featureName = scenario.getUri.toURL.getFile.take(250)
+    val featureName = scenario.getUri.toURL.getFile.split('/').last
     val scenarioName = scenario.getName.take(250)
-    println("===> " + featureName.take(250))
-    println("===> " + scenarioName.take(250))
-    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
-    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
-    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+    println("===> " + featureName)
+    println("===> " + scenarioName)
+//    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+//    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+//    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
     webDriver = initDriver
   }
 

--- a/src/test/scala/steps/Steps.scala
+++ b/src/test/scala/steps/Steps.scala
@@ -65,9 +65,9 @@ class Steps extends ScalaDsl with EN {
     val scenarioName = scenario.getName.take(250)
     println("===> " + featureName)
     println("===> " + scenarioName)
-//    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
-//    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
-//    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
+    differentUserCredentials = differentUserCredentials.copy(lastName = featureName, firstName = scenarioName)
+    userCredentials = userCredentials.copy(lastName = featureName, firstName = scenarioName)
     webDriver = initDriver
   }
 


### PR DESCRIPTION
As a Before for each scenario we put the feature and scenario in the UserCredentials as last and first name so that we can easily see source of any uncleaned-up test users in the KeyCloak console.

This needs  a`var` to allow update of the credentials for each scenario in a feature.  To ensure that these have been set before we we make "clients" that val needs to be lazy (e.g.):

 `lazy val client = GraphqlUtility(userCredentials)` 